### PR TITLE
Fixed element component

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 ## Version History
 
+### v. 0.0.19
+
+-   **Element Generator Fix**: `page-composer:element` now also creates the preview Blade component
+    -   Added preview stub generation alongside class and Livewire view generation
+    -   Preview files are now created in `resources/views/components/page-composer-elements/`
+-   **Element Registration Validation**: Manual element registration now validates preview file presence
+    -   Validation now checks class file, Livewire view file, and preview Blade file before saving
+    -   Added clear validation error message when preview file is missing
+-   **Path Alignment**: Unified preview component paths across creation and validation flows
+    -   Generator output path and admin validation path now point to the same directory
+
 ### v. 0.0.18
 
 -   **Element Component Registration**: Enhanced manual component registration workflow

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "flobbos/page-composer",
+    "version": "0.0.19",
     "description": "A livewire based CMS for Laravel",
     "keywords": [
         "laravel",

--- a/src/PageComposer/Console/Commands/MakeElementCommand.php
+++ b/src/PageComposer/Console/Commands/MakeElementCommand.php
@@ -46,6 +46,10 @@ class MakeElementCommand extends GeneratorCommand
       'view' => [
         'src' => base_path('vendor/flobbos/page-composer/src/resources/stubs') . '/element.blade.php.stub',
         'dest' => resource_path('views/livewire/page-composer-elements')
+      ],
+      'preview' => [
+        'src' => base_path('vendor/flobbos/page-composer/src/resources/stubs') . '/preview-element.blade.php.stub',
+        'dest' => resource_path('/views/components/page-composer-elements')
       ]
     ];
   }
@@ -57,6 +61,9 @@ class MakeElementCommand extends GeneratorCommand
 
     // Generate view
     $this->generateView();
+
+    // Generate preview component
+    $this->generatePreview();
   }
 
   /**
@@ -92,6 +99,20 @@ class MakeElementCommand extends GeneratorCommand
     $this->generateStub('view', $viewName . '.blade.php');
 
     $this->info($this->type . '-View created successfully.');
+  }
+
+  /**
+   * Generate preview blade component from stub
+   *
+   * @throws FileNotFoundException
+   */
+  protected function generatePreview(): void
+  {
+    $viewName = $this->getViewName();
+
+    $this->generateStub('preview', $viewName . '.blade.php');
+
+    $this->info($this->type . '-Preview created successfully.');
   }
 
   /**

--- a/src/PageComposer/Livewire/ElementComponent.php
+++ b/src/PageComposer/Livewire/ElementComponent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Flobbos\PageComposer\Livewire;;
+namespace Flobbos\PageComposer\Livewire;
 
 
 use Illuminate\Support\Facades\Artisan;
@@ -47,6 +47,7 @@ class ElementComponent extends Component
             // Validate that component files exist
             $classFile = app_path('Livewire/PageComposerElements/' . Str::studly($this->componentName) . '.php');
             $viewFile = resource_path('views/livewire/page-composer-elements/' . Str::slug($this->componentName) . '.blade.php');
+            $previewFile = resource_path('/views/components/page-composer-elements/' . Str::slug($this->componentName) . '.blade.php');
 
             if (!file_exists($classFile)) {
                 $this->addError('componentName', "Component class file not found at: app/Livewire/PageComposerElements/" . Str::studly($this->componentName) . ".php");
@@ -55,6 +56,11 @@ class ElementComponent extends Component
 
             if (!file_exists($viewFile)) {
                 $this->addError('componentName', "Component view file not found at: resources/views/livewire/page-composer-elements/" . Str::slug($this->componentName) . ".blade.php");
+                return;
+            }
+
+            if (!file_exists($previewFile)) {
+                $this->addError('componentName', "Component preview file not found at: resources/views/components/page-composer-elements/" . Str::slug($this->componentName) . ".blade.php");
                 return;
             }
         }

--- a/src/resources/stubs/preview-element.blade.php.stub
+++ b/src/resources/stubs/preview-element.blade.php.stub
@@ -1,0 +1,4 @@
+@props(['content' => []])
+<div>
+    {{-- YOUR ELEMENT PREVIEW --}}
+</div>

--- a/src/resources/views/livewire/element-component.blade.php
+++ b/src/resources/views/livewire/element-component.blade.php
@@ -108,7 +108,8 @@
                         <p class="mt-2 text-xs text-gray-500">
                             {{ __('Expected paths:') }}<br>
                             • <code class="text-xs">app/Livewire/PageComposerElements/{{ Str::studly($componentName) }}.php</code><br>
-                            • <code class="text-xs">resources/views/livewire/page-composer-elements/{{ Str::slug($componentName) }}.blade.php</code>
+                            • <code class="text-xs">resources/views/livewire/page-composer-elements/{{ Str::slug($componentName) }}.blade.php</code><br>
+                            • <code class="text-xs">resources/views/components/page-composer-elements/{{ Str::slug($componentName) }}.blade.php</code>
                         </p>
                         @error('componentName')
                             <span class="block mt-2 text-xs italic text-red-600">{{ $message }}</span>


### PR DESCRIPTION
-   **Element Generator Fix**: `page-composer:element` now also creates the preview Blade component
    -   Added preview stub generation alongside class and Livewire view generation
    -   Preview files are now created in `resources/views/components/page-composer-elements/`
-   **Element Registration Validation**: Manual element registration now validates preview file presence
    -   Validation now checks class file, Livewire view file, and preview Blade file before saving
    -   Added clear validation error message when preview file is missing
-   **Path Alignment**: Unified preview component paths across creation and validation flows
    -   Generator output path and admin validation path now point to the same directory