### PR TITLE
Refactor PageComposer: traits, services, transactions, tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor/
 composer.lock
 coverage/
+.phpunit.cache/
 /nbproject/private/
 /nbproject
 /.vscode

--- a/README.md
+++ b/README.md
@@ -184,14 +184,19 @@ Here you can set some basic validation options that will be used for saving a pa
 
 ```php
 'rules' => [
-        'page.name' => 'required', //mandatory
-        'page.photo' => 'required',
-        'page.slider_image' => 'sometimes:image',
-        'page.newsletter_image' => 'sometimes:image',
+        'pageData.name' => 'required', //mandatory
+        'pageData.photo' => 'required',
+        'pageData.slider_image' => 'sometimes:image',
+        'pageData.newsletter_image' => 'sometimes:image',
         'pageTranslations.*.content.title' => 'required', //mandatory
-        'page.category_id' => 'required', //remove if not using categories
+        'pageData.category_id' => 'required', //remove if not using categories
     ],
 ```
+
+> The rule keys reference the public `$pageData` array on the PageComposer
+> Livewire component. The `pageData.*` prefix is mandatory — bare `name`,
+> `photo`, etc. won't match. (See the 1.x → 2.x upgrade notes if you're
+> coming from 1.0.x where these were keyed under `page.*`.)
 
 ### FAQ
 
@@ -317,10 +322,110 @@ layout path suggested by Livewire 3. Set the following option for the correct la
 
 | Laravel | PageComposer |
 | :------ | :----------- |
-| 13.x    | 1.x          |
+| 13.x    | 2.x, 1.x     |
 | 10-12.x | 0.1.x        |
 
-PageComposer 1.x requires Laravel 13, Livewire 4, and PHP 8.3+. Use 1.0.2 or newer — 1.0.0 was broken (Packagist rejected it) and 1.0.1 only fixed the Packagist issue.
+PageComposer 2.x and 1.x both require Laravel 13, Livewire 4, and PHP 8.3+. 2.x is a structural rewrite of the editor component (now broken into traits + services with a typed property surface) and adds a Pest 4 test suite. See the upgrade notes below for the breaking changes.
+
+## Upgrading from 1.x to 2.x
+
+2.x keeps the same Laravel / Livewire / PHP minimums as 1.x, but ships several breaking changes from a structural rewrite of the `PageComposer` Livewire component. None of them touch the database; the migrations are unchanged.
+
+### 1. Validation rule keys: `page.*` → `pageData.*`
+
+The public property holding the form state was renamed from `$page` to a typed `?array $pageData = null`, distinct from `mount`'s `$page` route-binding parameter. **If you published the config**, update the keys in your `config/pagecomposer.php`:
+
+```diff
+ 'rules' => [
+-    'page.name' => 'required',
+-    'page.photo' => 'required',
+-    'page.slider_image' => 'sometimes:image',
+-    'page.newsletter_image' => 'sometimes:image',
++    'pageData.name' => 'required',
++    'pageData.photo' => 'required',
++    'pageData.slider_image' => 'sometimes:image',
++    'pageData.newsletter_image' => 'sometimes:image',
+     'pageTranslations.*.content.title' => 'required',
+-    'page.category_id' => 'required',
++    'pageData.category_id' => 'required',
+ ],
+```
+
+If you have custom validation messages or translation keys referencing `page.*`, rename those too.
+
+### 2. Row / column children now bind via `wire:model`, not `:row=` / `:column=`
+
+`RowComponent::$row` and `ColumnComponent::$column` are now `#[Modelable]`. The whole dispatch-back-up chain (`itemsUpdated.{target}` → `columnUpdated` → `rowUpdated`) has been removed.
+
+If you customized either view, update the child tags:
+
+```diff
+- <livewire:row-component :row="$row" :rowKey="$rowKey" :previewMode="$previewMode" />
++ <livewire:row-component wire:model="rows.{{ $currentLanguage->locale }}.rows.{{ $rowKey }}" :rowKey="$rowKey" :previewMode="$previewMode" />
+
+- <livewire:column-component :column="$column" :columnKey="$columnKey" target="{{ $source }}" />
++ <livewire:column-component wire:model="row.columns.{{ $columnKey }}" :columnKey="$columnKey" />
+```
+
+The `target` attribute on `<livewire:column-component>` is gone, and `RowComponent::$source` no longer exists.
+
+If your code dispatched or listened for `rowUpdated`, `columnUpdated`, or `itemsUpdated.*`, those events are no longer in the parent/child sync path. Use Modelable on your own components or fall back to direct property writes through the bound state.
+
+### 3. Image upload now needs `fieldName`
+
+`ImageUploadComponent` includes `fieldName` in its dispatched payload, and `PageComposer`'s listeners use it to route the value to the right photo field. Update any custom view that mounts an upload component for the page composer:
+
+```diff
+ <livewire:image-upload-component
+     existingImage="{{ $photo }}"
+     eventTarget="pageComposer.mainPhoto"
++    fieldName="photo"
+     imagePath="photos/" />
+```
+
+Allowed `fieldName` values for the bundled `PageComposer` listener: `photo`, `newsletter_image`, `slider_image`. Any other value is silently ignored.
+
+### 4. Several public properties are now `#[Locked]`
+
+These are server-controlled and reject frontend writes via Livewire payloads: `$elements`, `$pageId`, `$exceptionMessage`, `$showErrorMessage`, `$categories`, `$tags`, `$photo`, `$newsletter_image`, `$slider_image`, `$languages`, `$currentLanguage`, `$availableLanguages`, `$selectableLanguages`. If you had a `wire:model` pointed at any of these, it will throw `CannotUpdateLockedPropertyException`. Use the appropriate event (`addLanguage`, `setLanguage`, the `eventImageUploadComponent*` events, etc.) instead.
+
+### 5. Save / update errors are now sanitized
+
+Previously the user saw `$ex->getMessage() . ' ' . $ex->getLine() . ' ' . $ex->getFile()` in a flash error and on-page banner, which leaked filesystem paths. 2.x reports the exception via `report($ex)` and shows a generic message ("We could not save this page. Please try again."). Configure your error reporter (Sentry, Bugsnag, etc.) if you want the detail elsewhere.
+
+### 6. New service classes
+
+Persistence and caching moved out of the Livewire component:
+
+- `Flobbos\PageComposer\Services\PageBuilder` — transactional save/update of Page + translations + rows + columns + items
+- `Flobbos\PageComposer\Services\PageBuilderResult` — readonly DTO returned by `PageBuilder::persist`
+- `Flobbos\PageComposer\Services\PageComposerCache` — single entry point for `elements()`, `languages()`, `categories()`, `tags()`, plus `forgetAll()`
+- `Flobbos\PageComposer\Services\SortService` — the row/column reorder algorithm
+
+If you extended the editor component, you can resolve these via the container.
+
+### 7. Component split into concern traits
+
+`PageComposer` is now ~330 lines of orchestration plus four traits under `Flobbos\PageComposer\Livewire\Concerns`:
+
+- `HandlesImageUploads` — `$photo`, `$newsletter_image`, `$slider_image` + the two listener pair + `setPhotoField()`
+- `HandlesTemplates` — `saveTemplate`, `loadTemplate`, `selectTemplate`, `$templateName`, `$selectedTemplate`
+- `InteractsWithLanguages` — language props, `addLanguage`, `setLanguage`, `setRowsLanguage`, `hydrateLanguages`, `copyContent`, `languageAdded` listener
+- `ManagesRows` — `$rows`, `$showMiniMap`, `addRow`, `updateRowSorting`, sort helpers, `deleteRow` listener
+
+If you extended `PageComposer` to override one of those methods, the override may now need to be on the trait or via a host-app trait that re-uses our trait.
+
+### 8. Configurable date format
+
+`DatePicker` and `PageComposer::dateSelected` no longer hard-code `m-d-Y`. They read `pagecomposer.date_format`, default `'m-d-Y'` for backward compatibility. Recommended for new installs:
+
+```php
+'date_format' => 'Y-m-d', // ISO 8601, locale-neutral
+```
+
+### 9. Pest plugins on the v4 line
+
+The package's dev dependencies on `pestphp/pest-plugin-laravel` and `pestphp/pest-plugin-livewire` are now `^4.0`, requiring Pest 4. If you run `vendor/bin/pest` against the package, run `composer update` first.
 
 ## Upgrading from 0.1.x to 1.x
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,43 @@
 ## Version History
 
+### v. 2.0.0
+
+A structural rewrite of the `PageComposer` Livewire component. Same Laravel 13 / Livewire 4 / PHP 8.3 baseline as 1.x, no schema changes. See the `Upgrading from 1.x to 2.x` section in the README for migration steps.
+
+#### Breaking
+
+- **Validation rule keys** moved from `page.*` to `pageData.*`. The form-state property was renamed from `$page` (untyped, colliding with mount's `{page}` route param) to `?array $pageData = null`. Published configs need updating; see the upgrade guide.
+- **Row / column parent-child sync** now uses Livewire 4's `#[Modelable]` instead of a three-hop dispatch chain. `RowComponent::$row` and `ColumnComponent::$column` are bound via `wire:model="..."` from their parents. Removed: `itemsUpdated.{target}` / `columnUpdated` / `rowUpdated` events, `RowComponent::$source`, `ColumnComponent::$target`, and the matching listeners.
+- **Image upload listener routing** now reads a `field` payload from `ImageUploadComponent`. Any view mounting an upload component for the page composer must pass `fieldName="..."` (allowed: `photo`, `newsletter_image`, `slider_image`). Six copy-paste listener methods on the orchestrator collapsed to two stacked-attribute methods + a whitelisted `setPhotoField` helper.
+- **Server-controlled props are `#[Locked]`** (frontend can no longer write to them via wire:model): `$elements`, `$pageId`, `$exceptionMessage`, `$showErrorMessage`, `$categories`, `$tags`, `$photo`, `$newsletter_image`, `$slider_image`, `$languages`, `$currentLanguage`, `$availableLanguages`, `$selectableLanguages`.
+- **Sanitized error messages.** Save / update no longer flash `$ex->getMessage() . ' ' . $ex->getLine() . ' ' . $ex->getFile()` to the user (filesystem path leak); they `report($ex)` and surface a generic message instead.
+- **Configurable date format.** `pagecomposer.date_format` controls the date picker's display/parse format (default `'m-d-Y'` for parity; `'Y-m-d'` recommended for new installs).
+- **Pest plugin dependencies bumped to `^4.0`** (`pestphp/pest-plugin-laravel`, `pestphp/pest-plugin-livewire`); both have Laravel 13 / Livewire 4 compatible 4.x releases.
+
+#### Architecture
+
+- New service classes under `Flobbos\PageComposer\Services\`:
+    - `PageBuilder` + `PageBuilderResult`: transactional upsert of Page + tags + translations + rows + columns + items. Replaces the duplicated `saveContent` / `updateContent` triple-nested foreach loops.
+    - `PageComposerCache`: one entry point for the four cached lookup tables (elements, languages, categories, tags) with `forgetAll()`.
+    - `SortService`: shared row/column reorder algorithm.
+- `PageComposer` Livewire component split into four traits under `Flobbos\PageComposer\Livewire\Concerns\`: `HandlesImageUploads`, `HandlesTemplates`, `InteractsWithLanguages`, `ManagesRows`. Component file dropped from 902 to ~330 lines.
+- `PageComposerServiceProvider` Livewire registration is now driven by a class-list constant + a `Str::kebab(class_basename(...))` loop, replacing 17 individual `Livewire::component(...)` calls.
+
+#### Robustness
+
+- `saveContent` and `updateContent` (now thin wrappers around `PageBuilder::persist`) are wrapped in `DB::transaction`. A mid-save exception no longer leaves orphan rows / columns / column items.
+- Languages are pre-loaded once per save instead of issued per-translation and per-row via `Language::where('locale', $key)->first()`.
+- `ElementComponent::render()` reads from `PageComposerCache` instead of issuing `Element::all()` on every render. `saveElement` and `updateElement` bust the cache after writing.
+
+#### Tests
+
+- New Pest 4 suite: 35 tests, 94 assertions, in-memory sqlite via Orchestra Testbench.
+    - `tests/Unit/SortServiceTest.php` (8) — pure-function reorder coverage.
+    - `tests/Feature/PageComposerCacheTest.php` (7) — cache hit/refresh/forget across all four lookups.
+    - `tests/Feature/PageBuilderTest.php` (12) — create/update Page, translation upsert, tag sync, row/column/item persistence, transaction rollback, locale skipping, available_space recompute.
+    - `tests/Feature/PageComposerComponentTest.php` (8) — component-level: mount default + hydrate, validation blocks, happy-path save, rollback safety with sanitized error, deleteRow listener, imageSaved listener whitelist.
+- `tests/Fixtures/StubElement.php` registered under `page-composer-elements.{text,photo,youtube}` so the orchestrator's view renders without the host-app element classes being present.
+
 ### v. 1.0.3
 
 - **Feature**: Expanded the default Quill toolbar. In addition to the Normal / H1–H3 dropdown, it now includes bold / italic / underline, ordered + bullet lists, link, and clear-formatting.

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 A structural rewrite of the `PageComposer` Livewire component. Same Laravel 13 / Livewire 4 / PHP 8.3 baseline as 1.x, no schema changes. See the `Upgrading from 1.x to 2.x` section in the README for migration steps.
 
+#### Feature: deferred structural deletes
+
+Row / column / element removal is now staged in the editor state and only persisted to the database when the page is saved. A page refresh before save restores the removed content. On save, `PageBuilder::persist` scans for orphans (rows / columns / column items present in the DB but absent from the in-memory state tree) and deletes them inside the same transaction as the upsert. Confirm-dialog copy in the row and column views now reads "Applied when you save the page."
+
 #### Breaking
 
 - **Validation rule keys** moved from `page.*` to `pageData.*`. The form-state property was renamed from `$page` (untyped, colliding with mount's `{page}` route param) to `?array $pageData = null`. Published configs need updating; see the upgrade guide.

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^10.0 || ^11.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
-        "pestphp/pest-plugin-livewire": "^3.0"
+        "pestphp/pest": "^3.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
     },
     "require-dev": {
         "orchestra/testbench": "^10.0 || ^11.0",
-        "pestphp/pest": "^3.0"
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.0",
+        "pestphp/pest-plugin-livewire": "^4.0"
     },
     "extra": {
         "laravel": {

--- a/src/PageComposer/Livewire/ColumnComponent.php
+++ b/src/PageComposer/Livewire/ColumnComponent.php
@@ -2,7 +2,6 @@
 
 namespace Flobbos\PageComposer\Livewire;
 
-use Flobbos\PageComposer\Models\ColumnItem;
 use Flobbos\PageComposer\Models\Element;
 use Illuminate\Support\Arr;
 use Livewire\Attributes\Computed;
@@ -58,13 +57,13 @@ class ColumnComponent extends Component
         $this->column['column_items'][$itemKey] = $data;
     }
 
+    /**
+     * Stage an element removal in component state. The column item is
+     * only removed from the DB when the page is saved, via PageBuilder's
+     * orphan purge. A refresh before save therefore restores the element.
+     */
     public function deleteElement(int $itemKey)
     {
-        if (isset($this->column['column_items'][$itemKey]['id'])) {
-            if ($columnItem = ColumnItem::find($this->column['column_items'][$itemKey]['id'])) {
-                $columnItem->delete();
-            }
-        }
         unset($this->column['column_items'][$itemKey]);
         unset($this->sortedElements);
 

--- a/src/PageComposer/Livewire/ColumnComponent.php
+++ b/src/PageComposer/Livewire/ColumnComponent.php
@@ -2,21 +2,32 @@
 
 namespace Flobbos\PageComposer\Livewire;
 
-use Flobbos\PageComposer\Models\Element;
-use Livewire\Component;
 use Flobbos\PageComposer\Models\ColumnItem;
+use Flobbos\PageComposer\Models\Element;
 use Illuminate\Support\Arr;
-use Livewire\Attributes\On;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Modelable;
+use Livewire\Attributes\On;
+use Livewire\Component;
 
 class ColumnComponent extends Component
 {
+    /**
+     * Bound to the parent's $row['columns'][columnKey] via wire:model.
+     * Mutations propagate up automatically; no dispatch chain needed.
+     */
+    #[Modelable]
     public $column;
 
-    public $columnKey, $previewMode;
+    public $columnKey;
+    public $previewMode;
 
+    /**
+     * Used as the dispatch suffix for events emitted by published
+     * page-composer-elements.* components (elementAdded.{source} /
+     * elementUpdated.{source}). Generated per-instance.
+     */
     public $source;
-    public $target;
 
     public function mount()
     {
@@ -30,23 +41,21 @@ class ColumnComponent extends Component
 
     public function saveColumnSettings()
     {
-        $this->dispatchChanges();
+        // No-op now that Modelable propagates mutations to the parent.
+        // Kept so the existing wire:click in the column-settings panel
+        // still resolves.
     }
 
     #[On('elementAdded.{source}')]
     public function elementAdded(Element $element)
     {
         $this->column['column_items'][] = $this->generateElement($element);
-
-        $this->dispatchChanges();
     }
 
     #[On('elementUpdated.{source}')]
     public function elementUpdated(array $data, int $itemKey)
     {
         $this->column['column_items'][$itemKey] = $data;
-
-        $this->dispatchChanges();
     }
 
     public function deleteElement(int $itemKey)
@@ -67,7 +76,6 @@ class ColumnComponent extends Component
         }
 
         unset($this->sortedElements);
-        $this->dispatchChanges();
     }
 
     #[Computed]
@@ -80,17 +88,16 @@ class ColumnComponent extends Component
 
     public function getElementPositionArray($itemKey)
     {
-        //Disabled positioning array
         $position = [
             'up' => false,
             'down' => false,
             'position' => 1
         ];
-        //more than one element enable positioning
+
         if ($count = count($this->column['column_items'])) {
             $position = [
-                'up' => $this->column['column_items'][$itemKey]['sorting'] > 1 ? true : false,
-                'down' => $this->column['column_items'][$itemKey]['sorting'] < count($this->column['column_items']) ? true : false,
+                'up' => $this->column['column_items'][$itemKey]['sorting'] > 1,
+                'down' => $this->column['column_items'][$itemKey]['sorting'] < count($this->column['column_items']),
                 'position' => $this->column['column_items'][$itemKey]['sorting']
             ];
         }
@@ -100,37 +107,25 @@ class ColumnComponent extends Component
     public function sortElementDown($itemKey)
     {
         $sortedElements = $this->sortedElements;
-        //Advance array to correct position
         while (key($sortedElements) !== $itemKey) next($sortedElements);
-        //Set the values at the current position
         $current = current($sortedElements);
         $this->column['column_items'][$itemKey]['sorting'] = $current['sorting'] + 1;
-        //Set the value for the next element
         if ($next = next($sortedElements)) {
             $this->column['column_items'][key($sortedElements)]['sorting'] = $next['sorting'] - 1;
         }
-        // Invalidate the cached computed so render() sees the new order.
         unset($this->sortedElements);
-        //Emit the change
-        $this->dispatchChanges();
     }
 
     public function sortElementUp($itemKey)
     {
         $sortedElements = $this->sortedElements;
-        //Advance array to correct position
         while (key($sortedElements) !== $itemKey) next($sortedElements);
-        //Set the values at the current position
         $current = current($sortedElements);
-        $this->column['column_items'][$itemKey]['sorting'] =  $current['sorting'] - 1;
-        //Set the value for the previous element
+        $this->column['column_items'][$itemKey]['sorting'] = $current['sorting'] - 1;
         if ($prev = prev($sortedElements)) {
             $this->column['column_items'][key($sortedElements)]['sorting'] = $prev['sorting'] + 1;
         }
-        // Invalidate the cached computed so render() sees the new order.
         unset($this->sortedElements);
-        //Emit the change
-        $this->dispatchChanges();
     }
 
     public function generateElement($element)
@@ -145,10 +140,5 @@ class ColumnComponent extends Component
             'active' => true,
             'content' => []
         ];
-    }
-
-    public function dispatchChanges()
-    {
-        $this->dispatch('itemsUpdated.' . $this->target, column: $this->column, columnKey: $this->columnKey);
     }
 }

--- a/src/PageComposer/Livewire/Concerns/HandlesImageUploads.php
+++ b/src/PageComposer/Livewire/Concerns/HandlesImageUploads.php
@@ -2,6 +2,7 @@
 
 namespace Flobbos\PageComposer\Livewire\Concerns;
 
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 
 /**
@@ -11,9 +12,14 @@ trait HandlesImageUploads
 {
     private const PHOTO_FIELDS = ['photo', 'newsletter_image', 'slider_image'];
 
-    public $photo;
-    public $newsletter_image;
-    public $slider_image;
+    #[Locked]
+    public ?string $photo = null;
+
+    #[Locked]
+    public ?string $newsletter_image = null;
+
+    #[Locked]
+    public ?string $slider_image = null;
 
     #[On('eventImageUploadComponentSaved.pageComposer.mainPhoto')]
     #[On('eventImageUploadComponentSaved.pageComposer.newsletterImage')]

--- a/src/PageComposer/Livewire/Concerns/HandlesImageUploads.php
+++ b/src/PageComposer/Livewire/Concerns/HandlesImageUploads.php
@@ -44,6 +44,6 @@ trait HandlesImageUploads
         }
 
         $this->{$field} = $value;
-        $this->page[$field] = $value;
+        $this->pageData[$field] = $value;
     }
 }

--- a/src/PageComposer/Livewire/Concerns/HandlesImageUploads.php
+++ b/src/PageComposer/Livewire/Concerns/HandlesImageUploads.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Flobbos\PageComposer\Livewire\Concerns;
+
+use Livewire\Attributes\On;
+
+/**
+ * @property array|null $page
+ */
+trait HandlesImageUploads
+{
+    private const PHOTO_FIELDS = ['photo', 'newsletter_image', 'slider_image'];
+
+    public $photo;
+    public $newsletter_image;
+    public $slider_image;
+
+    #[On('eventImageUploadComponentSaved.pageComposer.mainPhoto')]
+    #[On('eventImageUploadComponentSaved.pageComposer.newsletterImage')]
+    #[On('eventImageUploadComponentSaved.pageComposer.sliderImage')]
+    public function imageSaved(string $field, string $imagePath, ?int $itemIndex = null): void
+    {
+        $this->setPhotoField($field, $imagePath);
+    }
+
+    #[On('eventImageUploadComponentDeleted.pageComposer.mainPhoto')]
+    #[On('eventImageUploadComponentDeleted.pageComposer.newsletterImage')]
+    #[On('eventImageUploadComponentDeleted.pageComposer.sliderImage')]
+    public function imageDeleted(string $field, ?string $imagePath = null, ?int $itemIndex = null): void
+    {
+        $this->setPhotoField($field, null);
+    }
+
+    private function setPhotoField(string $field, ?string $value): void
+    {
+        if (!in_array($field, self::PHOTO_FIELDS, true)) {
+            return;
+        }
+
+        $this->{$field} = $value;
+        $this->page[$field] = $value;
+    }
+}

--- a/src/PageComposer/Livewire/Concerns/HandlesTemplates.php
+++ b/src/PageComposer/Livewire/Concerns/HandlesTemplates.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Flobbos\PageComposer\Livewire\Concerns;
+
+use Flobbos\PageComposer\Models\Language;
+use Flobbos\PageComposer\Models\PageTemplate;
+use Illuminate\Support\Arr;
+
+/**
+ * @property array $rows
+ * @property array $pageTranslations
+ */
+trait HandlesTemplates
+{
+    public $templateName;
+    public $selectedTemplate;
+
+    public function saveTemplate(): void
+    {
+        $this->validate([
+            'templateName' => 'required',
+        ], ['required' => '(required)']);
+
+        $languages = collect($this->pageTranslations)
+            ->pluck('language_id')
+            ->all();
+
+        $content = $this->rows;
+        foreach ($content as $langKey => $lang) {
+            foreach (Arr::get($lang, 'rows', []) as $rowKey => $row) {
+                foreach (Arr::get($row, 'columns', []) as $columnKey => $column) {
+                    foreach (Arr::get($column, 'column_items', []) as $itemKey => $item) {
+                        $content[$langKey]['rows'][$rowKey]['columns'][$columnKey]['column_items'][$itemKey]['content'] = [];
+                    }
+                }
+            }
+        }
+
+        PageTemplate::create([
+            'name' => $this->templateName,
+            'content' => $content,
+            'languages' => $languages,
+            'user_id' => auth()->id(),
+        ]);
+
+        $this->resetErrorBag();
+        $this->reset('templateName');
+        session()->flash('template_saved', '(saved)');
+    }
+
+    public function selectTemplate()
+    {
+        return redirect()->route('page-composer::pages.create', ['template' => $this->selectedTemplate]);
+    }
+
+    public function loadTemplate($templateId): void
+    {
+        $template = PageTemplate::find($templateId);
+        $languages = Language::whereIn('id', $template->languages)->get();
+
+        foreach ($languages as $lang) {
+            $this->pageTranslations[$lang->locale] = [];
+            $this->addLanguage($lang->id);
+        }
+
+        foreach ($template->content as $key => $rows) {
+            $this->rows[$key] = $rows;
+            $this->ensureUnsavedRowsHaveUuid($key);
+        }
+    }
+}

--- a/src/PageComposer/Livewire/Concerns/HandlesTemplates.php
+++ b/src/PageComposer/Livewire/Concerns/HandlesTemplates.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Arr;
  */
 trait HandlesTemplates
 {
-    public $templateName;
+    public ?string $templateName = null;
     public $selectedTemplate;
 
     public function saveTemplate(): void

--- a/src/PageComposer/Livewire/Concerns/InteractsWithLanguages.php
+++ b/src/PageComposer/Livewire/Concerns/InteractsWithLanguages.php
@@ -5,6 +5,7 @@ namespace Flobbos\PageComposer\Livewire\Concerns;
 use Flobbos\PageComposer\Models\Language;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 
 /**
@@ -13,9 +14,16 @@ use Livewire\Attributes\On;
  */
 trait InteractsWithLanguages
 {
+    #[Locked]
     public $languages;
+
+    #[Locked]
     public $currentLanguage;
+
+    #[Locked]
     public $availableLanguages;
+
+    #[Locked]
     public $selectableLanguages;
 
     public function addLanguage(int $language_id): void

--- a/src/PageComposer/Livewire/Concerns/InteractsWithLanguages.php
+++ b/src/PageComposer/Livewire/Concerns/InteractsWithLanguages.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Flobbos\PageComposer\Livewire\Concerns;
+
+use Flobbos\PageComposer\Models\Language;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Livewire\Attributes\On;
+
+/**
+ * @property array $rows
+ * @property array $pageTranslations
+ */
+trait InteractsWithLanguages
+{
+    public $languages;
+    public $currentLanguage;
+    public $availableLanguages;
+    public $selectableLanguages;
+
+    public function addLanguage(int $language_id): void
+    {
+        $selectedLanguage = $this->cache()->languages()->firstWhere('id', $language_id) ?? Language::find($language_id);
+
+        if (!$selectedLanguage) {
+            return;
+        }
+
+        if (empty($this->currentLanguage)) {
+            $this->currentLanguage = $selectedLanguage;
+        }
+
+        $this->pageTranslations[$selectedLanguage->locale]['language_id'] = $selectedLanguage->id;
+        $this->setRowsLanguage($selectedLanguage->id);
+
+        $this->hydrateLanguages();
+    }
+
+    public function setLanguage(int $language_id): void
+    {
+        $this->currentLanguage = $this->cache()->languages()->firstWhere('id', $language_id) ?? Language::find($language_id);
+    }
+
+    /**
+     * Copy all content from one language to another.
+     */
+    public function copyContent(string $source, string $target): void
+    {
+        $this->rows[$target] = $this->rows[$source];
+
+        foreach ($this->rows[$target]['rows'] as $rowKey => $row) {
+            Arr::forget($this->rows, $target . '.rows.' . $rowKey . '.id');
+            $this->rows[$target]['rows'][$rowKey]['uuid'] = (string) Str::uuid();
+            foreach (Arr::get($row, 'columns', []) as $columnKey => $column) {
+                Arr::forget($this->rows, $target . '.rows.' . $rowKey . '.columns.' . $columnKey . '.id');
+                foreach (Arr::get($column, 'column_items', []) as $itemKey => $item) {
+                    Arr::forget($this->rows, $target . '.rows.' . $rowKey . '.columns.' . $columnKey . '.column_items.' . $itemKey . '.id');
+                }
+            }
+        }
+
+        $language = Language::where('locale', $target)->first();
+        $this->addLanguage($language->id);
+    }
+
+    #[On('languageAdded')]
+    public function languageAdded(): void
+    {
+        // Language can be added during editing, so refresh this cache explicitly.
+        $this->cache()->languages(true);
+        $this->hydrateLanguages();
+    }
+
+    public function hydrateLanguages(): void
+    {
+        $this->languages = $this->cache()->languages();
+        $this->availableLanguages = collect();
+        $this->selectableLanguages = $this->languages;
+
+        foreach ($this->pageTranslations as $trans) {
+            if (isset($trans['language_id'])) {
+                $this->availableLanguages->push($this->languages->where('id', $trans['language_id'])->first());
+            }
+        }
+
+        foreach ($this->selectableLanguages as $key => $lang) {
+            if ($this->availableLanguages->contains('id', $lang->id)) {
+                $this->selectableLanguages->forget($key);
+            }
+        }
+    }
+
+    public function setRowsLanguage(int $language_id): void
+    {
+        $lang = $this->cache()->languages()->firstWhere('id', $language_id) ?? Language::find($language_id);
+
+        if (!$lang) {
+            return;
+        }
+
+        if (!isset($this->rows[$lang->locale])) {
+            $this->rows[$lang->locale] = [
+                'rows' => [],
+            ];
+        }
+
+        $this->ensureUnsavedRowsHaveUuid($lang->locale);
+    }
+}

--- a/src/PageComposer/Livewire/Concerns/ManagesRows.php
+++ b/src/PageComposer/Livewire/Concerns/ManagesRows.php
@@ -14,8 +14,8 @@ use Livewire\Attributes\On;
  */
 trait ManagesRows
 {
-    public $rows = [];
-    public $showMiniMap = false;
+    public array $rows = [];
+    public bool $showMiniMap = false;
 
     public function addRow(): void
     {

--- a/src/PageComposer/Livewire/Concerns/ManagesRows.php
+++ b/src/PageComposer/Livewire/Concerns/ManagesRows.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Flobbos\PageComposer\Livewire\Concerns;
+
+use Flobbos\PageComposer\Models\Row;
+use Flobbos\PageComposer\Services\SortService;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
+
+/**
+ * @property \Flobbos\PageComposer\Models\Language|null $currentLanguage
+ */
+trait ManagesRows
+{
+    public $rows = [];
+    public $showMiniMap = false;
+
+    public function addRow(): void
+    {
+        $this->rows[$this->currentLanguage->locale]['rows'][] = [
+            'uuid' => (string) Str::uuid(),
+            'columns' => [],
+            'attributes' => [],
+            'alignment' => 'center',
+            'expanded' => false,
+            'active' => true,
+            'sorting' => $this->rows[$this->currentLanguage->locale]['rows'] ? count($this->rows[$this->currentLanguage->locale]['rows']) + 1 : 1,
+            'available_space' => 12
+        ];
+    }
+
+    /**
+     * Update the sorting for the rows. Called by Livewire 4's wire:sort when
+     * a row is dropped in a new position in the mini map.
+     *
+     * @param string|int $id       sortable key from wire:sort:item (uuid, db id, or tmp-N)
+     * @param int        $position zero-based target position
+     */
+    public function updateRowSorting($id, $position): void
+    {
+        $locale = $this->currentLanguage->locale ?? null;
+        if (!$locale) {
+            return;
+        }
+
+        $rows = $this->rows[$locale]['rows'] ?? [];
+
+        $this->rows[$locale]['rows'] = app(SortService::class)->reorder(
+            $rows,
+            fn(array $row, $key) => $this->rowSortableKey($row, (int) $key),
+            $id,
+            (int) $position,
+        );
+    }
+
+    public function rowSortableKey(array $row, int $fallbackIndex): string
+    {
+        if (filled(Arr::get($row, 'id'))) {
+            return (string) Arr::get($row, 'id');
+        }
+
+        if (filled(Arr::get($row, 'uuid'))) {
+            return (string) Arr::get($row, 'uuid');
+        }
+
+        return 'tmp-' . $fallbackIndex;
+    }
+
+    #[Computed]
+    public function sortedRows(): array
+    {
+        if (!isset($this->currentLanguage)) {
+            return [];
+        }
+
+        if (empty($this->rows[$this->currentLanguage->locale]['rows'])) {
+            return [];
+        }
+
+        return Arr::sort($this->rows[$this->currentLanguage->locale]['rows'], function ($value) {
+            return $value['sorting'];
+        });
+    }
+
+    public function sortItems(array $items): array
+    {
+        return Arr::sort($items, function ($value) {
+            return $value['sorting'];
+        });
+    }
+
+    #[On('deleteRow')]
+    public function deleteRow(string $rowKey): void
+    {
+        if (isset($this->rows[$this->currentLanguage->locale]['rows'][$rowKey]['id'])) {
+            if ($row = Row::find($this->rows[$this->currentLanguage->locale]['rows'][$rowKey]['id'])) {
+                $row->delete();
+            }
+        }
+        unset($this->rows[$this->currentLanguage->locale]['rows'][$rowKey]);
+    }
+
+    #[On('rowUpdated')]
+    #[On('columnUpdated')]
+    public function rowUpdated(array $row, string $rowKey): void
+    {
+        $this->rows[$this->currentLanguage->locale]['rows'][$rowKey] = $row;
+    }
+
+    protected function ensureUnsavedRowsHaveUuid(string $locale): void
+    {
+        foreach (Arr::get($this->rows, $locale . '.rows', []) as $rowKey => $row) {
+            $this->rows[$locale]['rows'][$rowKey]['available_space'] = $this->calculateRowAvailableSpace(Arr::get($row, 'columns', []));
+
+            if (filled(Arr::get($row, 'id')) || filled(Arr::get($row, 'uuid'))) {
+                continue;
+            }
+
+            $this->rows[$locale]['rows'][$rowKey]['uuid'] = (string) Str::uuid();
+        }
+    }
+
+    protected function calculateRowAvailableSpace(array $columns): int
+    {
+        return max(0, 12 - (int) collect($columns)
+            ->sum(fn($column) => (int) Arr::get($column, 'column_size', 0)));
+    }
+}

--- a/src/PageComposer/Livewire/Concerns/ManagesRows.php
+++ b/src/PageComposer/Livewire/Concerns/ManagesRows.php
@@ -102,13 +102,6 @@ trait ManagesRows
         unset($this->rows[$this->currentLanguage->locale]['rows'][$rowKey]);
     }
 
-    #[On('rowUpdated')]
-    #[On('columnUpdated')]
-    public function rowUpdated(array $row, string $rowKey): void
-    {
-        $this->rows[$this->currentLanguage->locale]['rows'][$rowKey] = $row;
-    }
-
     protected function ensureUnsavedRowsHaveUuid(string $locale): void
     {
         foreach (Arr::get($this->rows, $locale . '.rows', []) as $rowKey => $row) {

--- a/src/PageComposer/Livewire/Concerns/ManagesRows.php
+++ b/src/PageComposer/Livewire/Concerns/ManagesRows.php
@@ -2,7 +2,6 @@
 
 namespace Flobbos\PageComposer\Livewire\Concerns;
 
-use Flobbos\PageComposer\Models\Row;
 use Flobbos\PageComposer\Services\SortService;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -91,14 +90,14 @@ trait ManagesRows
         });
     }
 
+    /**
+     * Stage a row removal in component state. The row is only removed from
+     * the DB when the page is saved, via PageBuilder's orphan purge. A
+     * refresh before save therefore restores the row.
+     */
     #[On('deleteRow')]
     public function deleteRow(string $rowKey): void
     {
-        if (isset($this->rows[$this->currentLanguage->locale]['rows'][$rowKey]['id'])) {
-            if ($row = Row::find($this->rows[$this->currentLanguage->locale]['rows'][$rowKey]['id'])) {
-                $row->delete();
-            }
-        }
         unset($this->rows[$this->currentLanguage->locale]['rows'][$rowKey]);
     }
 

--- a/src/PageComposer/Livewire/DatePicker.php
+++ b/src/PageComposer/Livewire/DatePicker.php
@@ -20,7 +20,7 @@ class DatePicker extends Component
     {
         $this->today = now();
         $this->startOfWeek = now()->startOfWeek();
-        $this->todayFormat = now()->format('m-d-Y');
+        $this->todayFormat = now()->format($this->dateFormat());
         $this->initDates();
     }
 
@@ -28,15 +28,21 @@ class DatePicker extends Component
     {
         $this->currentMonth = [];
         $this->tempDate = now()->createFromDate($this->today->year, $this->today->month, 1)->startOfWeek();
+        $format = $this->dateFormat();
         do {
             for ($i = 0; $i < 7; $i++) {
                 $this->currentMonth[] = [
                     'day' => $this->tempDate->day,
-                    'date' => $this->tempDate->format('m-d-Y')
+                    'date' => $this->tempDate->format($format)
                 ];
                 $this->tempDate->addDay();
             }
         } while ($this->tempDate->month == $this->today->month);
+    }
+
+    private function dateFormat(): string
+    {
+        return (string) config('pagecomposer.date_format', 'm-d-Y');
     }
 
     public function addMonth()

--- a/src/PageComposer/Livewire/ElementComponent.php
+++ b/src/PageComposer/Livewire/ElementComponent.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Str;
 use Livewire\Component;
 use Flobbos\PageComposer\Models\Element;
+use Flobbos\PageComposer\Services\PageComposerCache;
 
 class ElementComponent extends Component
 {
@@ -35,7 +36,7 @@ class ElementComponent extends Component
 
     public function render()
     {
-        $this->elements = Element::all();
+        $this->elements = app(PageComposerCache::class)->elements();
         return view('page-composer::livewire.element-component');
     }
 
@@ -71,6 +72,8 @@ class ElementComponent extends Component
             'icon' => $this->icon
         ]);
 
+        app(PageComposerCache::class)->elements(true);
+
         if ($this->createFromTemplate) {
             Artisan::call('page-composer:element ' . Str::studly($this->name));
         }
@@ -103,6 +106,8 @@ class ElementComponent extends Component
             'component' => $updatedComponentName,
             'icon' => $this->icon
         ]);
+
+        app(PageComposerCache::class)->elements(true);
 
         // Rename component files if they exist
         $originalClassFile = app_path('Livewire/PageComposerElements/' . Str::studly($originalComponentName) . '.php');

--- a/src/PageComposer/Livewire/ImageUploadComponent.php
+++ b/src/PageComposer/Livewire/ImageUploadComponent.php
@@ -55,7 +55,7 @@ class ImageUploadComponent extends Component
 
         $this->saved = true;
 
-        $this->dispatch('eventImageUploadComponentSaved.' . $this->eventTarget, imagePath: $this->imagePath . $filename, itemIndex: $this->itemIndex);
+        $this->dispatch('eventImageUploadComponentSaved.' . $this->eventTarget, field: $this->fieldName, imagePath: $this->imagePath . $filename, itemIndex: $this->itemIndex);
 
         $this->existingImage = $this->image;
 
@@ -88,7 +88,7 @@ class ImageUploadComponent extends Component
     {
         Storage::disk('public')->delete($this->existingImage);
 
-        $this->dispatch('eventImageUploadComponentDeleted.' . $this->eventTarget, imagePath: $this->existingImage, itemIndex: $this->itemIndex);
+        $this->dispatch('eventImageUploadComponentDeleted.' . $this->eventTarget, field: $this->fieldName, imagePath: $this->existingImage, itemIndex: $this->itemIndex);
 
         $this->reset('image', 'imageInput', 'existingImage');
     }

--- a/src/PageComposer/Livewire/PageComposer.php
+++ b/src/PageComposer/Livewire/PageComposer.php
@@ -211,8 +211,9 @@ class PageComposer extends Component
     #[On('dateSelected')]
     public function dateSelected(string $date): void
     {
-        $this->publishedOn = now()->createFromFormat('m-d-Y', $date);
-        $this->displayDate = $this->publishedOn->format('m-d-Y');
+        $format = (string) config('pagecomposer.date_format', 'm-d-Y');
+        $this->publishedOn = now()->createFromFormat($format, $date);
+        $this->displayDate = $this->publishedOn->format($format);
     }
 
     /**
@@ -304,7 +305,8 @@ class PageComposer extends Component
                 }
             }
             //Get publication date
-            $this->displayDate = $page->published_on ? $page->published_on->format('m-d-Y') : null;
+            $format = (string) config('pagecomposer.date_format', 'm-d-Y');
+            $this->displayDate = $page->published_on ? $page->published_on->format($format) : null;
             $this->publishedOn = $page->published_on;
             //Get category
             $this->pageCategory = $page->category;

--- a/src/PageComposer/Livewire/PageComposer.php
+++ b/src/PageComposer/Livewire/PageComposer.php
@@ -28,12 +28,11 @@ class PageComposer extends Component
     public $elements;
 
     /**
-     * Untyped because Livewire's nested-component machinery assigns the
-     * `page` route/attribute (an int id) to this property before mount()
-     * runs, then mount() rebuilds it as the page-state array via
-     * setPageContent(). Typing as ?array would reject the transient int.
+     * Page metadata for editing (name, photo, newsletter_image,
+     * slider_image, published_on, category_id). Distinct from mount's
+     * $page parameter, which carries the route-bound page id.
      */
-    public $page;
+    public ?array $pageData = null;
 
     #[Locked]
     public ?int $pageId = null;
@@ -71,11 +70,11 @@ class PageComposer extends Component
 
     private function syncPageState(): void
     {
-        $this->page['photo'] = $this->photo;
-        $this->page['newsletter_image'] = $this->newsletter_image;
-        $this->page['slider_image'] = $this->slider_image;
-        $this->page['published_on'] = $this->publishedOn;
-        $this->page['category_id'] = Arr::get($this->pageCategory, 'id');
+        $this->pageData['photo'] = $this->photo;
+        $this->pageData['newsletter_image'] = $this->newsletter_image;
+        $this->pageData['slider_image'] = $this->slider_image;
+        $this->pageData['published_on'] = $this->publishedOn;
+        $this->pageData['category_id'] = Arr::get($this->pageCategory, 'id');
     }
 
     public function mount($page = null)
@@ -187,7 +186,7 @@ class PageComposer extends Component
     {
         return app(PageBuilder::class)->persist(
             $this->pageId,
-            $this->page ?? [],
+            $this->pageData ?? [],
             $this->pageTranslations,
             $this->pageTags ?? [],
             $this->rows,
@@ -232,7 +231,7 @@ class PageComposer extends Component
     public function categorySelected($option): void
     {
         $this->pageCategory = $option;
-        $this->page['category_id'] = Arr::get($option, 'id');
+        $this->pageData['category_id'] = Arr::get($option, 'id');
     }
 
     /**
@@ -260,7 +259,7 @@ class PageComposer extends Component
         if (!is_null($id)) {
             $page = Page::find($id);
             //Set basic page information
-            $this->page = [
+            $this->pageData = [
                 'id' => $page->id,
                 'name' => $page->name,
                 'photo' => $page->photo,
@@ -319,8 +318,8 @@ class PageComposer extends Component
             // Tags ship as an array (matching the shape the tagsUpdated
             // listener writes) so $pageTags has one stable shape.
             $this->pageTags = $page->tags->toArray();
-        } elseif (is_null($this->page)) {
-            $this->page = [
+        } elseif (is_null($this->pageData)) {
+            $this->pageData = [
                 'name' => null,
                 'photo' => null,
                 'newsletter_image' => null,

--- a/src/PageComposer/Livewire/PageComposer.php
+++ b/src/PageComposer/Livewire/PageComposer.php
@@ -6,29 +6,18 @@ use Exception;
 use Livewire\Component;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
 use Flobbos\PageComposer\Models\Row;
-use Flobbos\PageComposer\Models\Tag;
 use Flobbos\PageComposer\Models\Page;
-use Flobbos\PageComposer\Models\Element;
-use Flobbos\PageComposer\Models\Category;
 use Flobbos\PageComposer\Models\Language;
 use Flobbos\PageComposer\Models\PageTemplate;
-use Flobbos\PageComposer\Models\TagTranslation;
-use Flobbos\PageComposer\Models\CategoryTranslation;
 use Flobbos\PageComposer\Services\PageBuilder;
 use Flobbos\PageComposer\Services\PageBuilderResult;
+use Flobbos\PageComposer\Services\PageComposerCache;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Computed;
 
 class PageComposer extends Component
 {
-    private const ELEMENTS_CACHE_KEY = 'page-composer.elements';
-    private const CATEGORIES_CACHE_KEY = 'page-composer.categories';
-    private const TAGS_CACHE_KEY = 'page-composer.tags';
-    private const LANGUAGES_CACHE_KEY = 'page-composer.languages';
-
     //page
     public $elements, $page, $pageId, $pageCategory;
     public $pageTags = [];
@@ -80,83 +69,20 @@ class PageComposer extends Component
     public function mount($page = null)
     {
         $this->pageId = $page;
-        $this->elements = $this->getCachedElements();
+        $this->elements = $this->cache()->elements();
         $this->setPageContent($this->pageId);
 
         if (request()->has('template')) {
             $this->loadTemplate(request()->get('template'));
         };
 
-        $this->categories = $this->getCachedCategories();
-        $this->tags = $this->getCachedTags();
+        $this->categories = $this->cache()->categories();
+        $this->tags = $this->cache()->tags();
     }
 
-    private function getCachedElements(bool $refresh = false): Collection
+    private function cache(): PageComposerCache
     {
-        if ($refresh) {
-            Cache::forget(self::ELEMENTS_CACHE_KEY);
-        }
-
-        $cached = Cache::remember(self::ELEMENTS_CACHE_KEY, now()->addMinutes(30), function () {
-            return Element::all()->toArray();
-        });
-
-        return Element::hydrate($cached);
-    }
-
-    private function getCachedLanguages(bool $refresh = false): Collection
-    {
-        if ($refresh) {
-            Cache::forget(self::LANGUAGES_CACHE_KEY);
-        }
-
-        $cached = Cache::remember(self::LANGUAGES_CACHE_KEY, now()->addMinutes(5), function () {
-            return Language::all()->toArray();
-        });
-
-        return Language::hydrate($cached);
-    }
-
-    private function getCachedCategories(bool $refresh = false): Collection
-    {
-        if ($refresh) {
-            Cache::forget(self::CATEGORIES_CACHE_KEY);
-        }
-
-        $cached = Cache::remember(self::CATEGORIES_CACHE_KEY, now()->addMinutes(30), function () {
-            return Category::with('translations')->get()->toArray();
-        });
-
-        return $this->hydrateWithTranslations(Category::class, CategoryTranslation::class, $cached);
-    }
-
-    private function getCachedTags(bool $refresh = false): Collection
-    {
-        if ($refresh) {
-            Cache::forget(self::TAGS_CACHE_KEY);
-        }
-
-        $cached = Cache::remember(self::TAGS_CACHE_KEY, now()->addMinutes(30), function () {
-            return Tag::with('translations')->get()->toArray();
-        });
-
-        return $this->hydrateWithTranslations(Tag::class, TagTranslation::class, $cached);
-    }
-
-    /**
-     * Rehydrate a collection of cached array rows into models with their
-     * `translations` relation restored. Caching arrays (rather than Eloquent
-     * Collections) avoids serialize/unserialize fragility across framework
-     * upgrades and cache driver changes.
-     */
-    private function hydrateWithTranslations(string $modelClass, string $translationClass, array $cached): Collection
-    {
-        return collect($cached)->map(function (array $row) use ($modelClass, $translationClass) {
-            $translations = Arr::pull($row, 'translations', []);
-            $model = $modelClass::hydrate([$row])->first();
-            $model->setRelation('translations', $translationClass::hydrate($translations));
-            return $model;
-        });
+        return app(PageComposerCache::class);
     }
 
     public function render()
@@ -195,7 +121,7 @@ class PageComposer extends Component
      */
     public function addLanguage(int $language_id): void
     {
-        $selectedLanguage = $this->getCachedLanguages()->firstWhere('id', $language_id) ?? Language::find($language_id);
+        $selectedLanguage = $this->cache()->languages()->firstWhere('id', $language_id) ?? Language::find($language_id);
 
         if (!$selectedLanguage) {
             return;
@@ -222,7 +148,7 @@ class PageComposer extends Component
      */
     public function setLanguage(int $language_id): void
     {
-        $this->currentLanguage = $this->getCachedLanguages()->firstWhere('id', $language_id) ?? Language::find($language_id);
+        $this->currentLanguage = $this->cache()->languages()->firstWhere('id', $language_id) ?? Language::find($language_id);
     }
 
     /**
@@ -407,7 +333,7 @@ class PageComposer extends Component
             $this->pageTranslations,
             $this->pageTags ?? [],
             $this->rows,
-            $this->getCachedLanguages()->keyBy('locale'),
+            $this->cache()->languages()->keyBy('locale'),
         );
     }
 
@@ -511,7 +437,7 @@ class PageComposer extends Component
     public function languageAdded(): void
     {
         // Language can be added during editing, so refresh this cache explicitly.
-        $this->getCachedLanguages(true);
+        $this->cache()->languages(true);
         $this->hydrateLanguages();
     }
 
@@ -523,7 +449,7 @@ class PageComposer extends Component
     #[On('componentAdded')]
     public function componentAdded(): void
     {
-        $this->elements = $this->getCachedElements(true);
+        $this->elements = $this->cache()->elements(true);
     }
 
     /**
@@ -684,7 +610,7 @@ class PageComposer extends Component
     public function hydrateLanguages(): void
     {
         //All languages
-        $this->languages = $this->getCachedLanguages();
+        $this->languages = $this->cache()->languages();
         $this->availableLanguages = collect();
         $this->selectableLanguages = $this->languages;
         //Available languages in article
@@ -711,7 +637,7 @@ class PageComposer extends Component
      */
     public function setRowsLanguage(int $language_id)
     {
-        $lang = $this->getCachedLanguages()->firstWhere('id', $language_id) ?? Language::find($language_id);
+        $lang = $this->cache()->languages()->firstWhere('id', $language_id) ?? Language::find($language_id);
 
         if (!$lang) {
             return;

--- a/src/PageComposer/Livewire/PageComposer.php
+++ b/src/PageComposer/Livewire/PageComposer.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Flobbos\PageComposer\Models\Row;
 use Flobbos\PageComposer\Models\Tag;
 use Flobbos\PageComposer\Models\Page;
@@ -367,59 +368,63 @@ class PageComposer extends Component
         $this->validate();
 
         try {
-            $page = $this->makePageModel();
-            $page->save();
-            $this->pageId = $page->id;
+            $languagesByLocale = $this->getCachedLanguages()->keyBy('locale');
 
-            //Sync tags
-            $selectedTags = [];
+            $page = DB::transaction(function () use ($languagesByLocale) {
+                $page = $this->makePageModel();
+                $page->save();
 
-            foreach ($this->pageTags as $tag) {
-                $selectedTags[] = $tag['id'];
-            }
+                $page->tags()->sync(collect($this->pageTags)->pluck('id')->all());
 
-            $page->tags()->sync($selectedTags);
-
-            //Create page translations
-            foreach ($this->pageTranslations as $key => $trans) {
-                if (! empty($trans['language_id'])) {
-                    $language = Language::where('locale', $key)->first();
+                foreach ($this->pageTranslations as $locale => $trans) {
+                    if (empty($trans['language_id'])) {
+                        continue;
+                    }
                     $trans['slug'] = Str::slug(Arr::get($trans, 'content.title'));
                     $page->translations()->save(new PageTranslation(array_merge($trans, ['page_id' => $page->id])));
                 }
-            }
-            //Save article content
-            foreach ($this->rows as $lang => $langRow) {
-                $language = Language::where('locale', $lang)->first();
 
-                foreach (Arr::get($langRow, 'rows', []) as $row) {
-                    $rowData = array_merge(Arr::except($row, ['uuid']), ['page_id' => $page->id, 'language_id' => $language->id]);
-                    $rowData['attributes'] = empty($rowData['attributes']) ? null : $rowData['attributes'];
-                    $rowData['available_space'] = $this->calculateRowAvailableSpace(Arr::get($row, 'columns', []));
-                    $newRow = Row::create($rowData);
+                foreach ($this->rows as $lang => $langRow) {
+                    $language = $languagesByLocale->get($lang);
+                    if (!$language) {
+                        continue;
+                    }
 
-                    foreach (Arr::get($row, 'columns', []) as $key => $column) {
-                        $newColumn = Column::create(array_merge($column, ['row_id' => $newRow->id]));
+                    foreach (Arr::get($langRow, 'rows', []) as $row) {
+                        $rowData = array_merge(Arr::except($row, ['uuid']), [
+                            'page_id' => $page->id,
+                            'language_id' => $language->id,
+                        ]);
+                        $rowData['attributes'] = empty($rowData['attributes']) ? null : $rowData['attributes'];
+                        $rowData['available_space'] = $this->calculateRowAvailableSpace(Arr::get($row, 'columns', []));
+                        $newRow = Row::create($rowData);
 
-                        foreach (Arr::get($column, 'column_items', []) as $key => $item) {
-                            $item = array_merge($item, ['column_id' => $newColumn->id]);
-                            $newColumnItem = ColumnItem::create(array_merge($item, ['column_id' => $newColumn->id]));
+                        foreach (Arr::get($row, 'columns', []) as $column) {
+                            $newColumn = Column::create(array_merge($column, ['row_id' => $newRow->id]));
+
+                            foreach (Arr::get($column, 'column_items', []) as $item) {
+                                ColumnItem::create(array_merge($item, ['column_id' => $newColumn->id]));
+                            }
                         }
                     }
                 }
-            }
 
+                return $page;
+            });
+
+            $this->pageId = $page->id;
             session()->flash('message', 'Page successfully saved.');
 
             if ($redirect) {
                 return redirect()->route('page-composer::pages.index');
-            } else {
-                return redirect()->route('page-composer::pages.edit', $page->id);
             }
-        } catch (Exception $ex) {
-            session()->flash('error', $ex->getMessage() . ' ' . $ex->getLine() . ' ' . $ex->getFile());
 
-            $this->exceptionMessage = $ex->getMessage() . ' ' . $ex->getLine() . ' ' . $ex->getFile();
+            return redirect()->route('page-composer::pages.edit', $page->id);
+        } catch (Exception $ex) {
+            report($ex);
+            $this->showErrorMessage = true;
+            $this->exceptionMessage = 'We could not save this page. Please try again.';
+            session()->flash('error', $this->exceptionMessage);
         }
     }
 
@@ -433,94 +438,83 @@ class PageComposer extends Component
         $this->validate();
 
         try {
-            $page = $this->makePageModel();
-            $page->save();
+            $languagesByLocale = $this->getCachedLanguages()->keyBy('locale');
 
-            //Sync tags
-            $selectedTags = [];
+            DB::transaction(function () use ($languagesByLocale) {
+                $page = $this->makePageModel();
+                $page->save();
 
-            foreach ($this->pageTags as $tag) {
-                $selectedTags[] = $tag['id'];
-            }
+                $page->tags()->sync(collect($this->pageTags)->pluck('id')->all());
 
-            $page->tags()->sync($selectedTags);
-
-            //Update page translations
-            foreach ($this->pageTranslations as $key => $trans) {
-                if (array_key_exists('id', $trans)) {
-                    $translation = PageTranslation::find($trans['id']);
+                foreach ($this->pageTranslations as $locale => $trans) {
                     $trans['slug'] = Str::slug(Arr::get($trans, 'content.title'));
-                    $translation->update($trans);
-                } else {
-                    $language = Language::where('locale', $key)->first();
-                    $trans['slug'] = Str::slug(Arr::get($trans, 'content.title'));
-                    $page->translations()->save(new PageTranslation(array_merge($trans, ['page_id' => $page->id])));
-                }
-            }
-            //Update article content
-            foreach ($this->rows as $lang => $langRow) {
-                $language = Language::where('locale', $lang)->first();
-                //Update rows
-                foreach (Arr::get($langRow, 'rows', []) as $rowKey => $row) {
-                    $rowPayload = Arr::except($row, ['uuid']);
-                    $rowPayload['available_space'] = $this->calculateRowAvailableSpace(Arr::get($row, 'columns', []));
-                    if (array_key_exists('id', $row)) {
-                        $newRow = Row::find($row['id']);
-                        $rowPayload['attributes'] = empty($rowPayload['attributes']) ? null : $rowPayload['attributes'];
-                        $newRow->update($rowPayload);
+                    if (array_key_exists('id', $trans)) {
+                        PageTranslation::find($trans['id'])->update($trans);
                     } else {
-                        $rowData = array_merge($rowPayload, ['page_id' => $page->id, 'language_id' => $language->id]);
-                        $rowData['attributes'] = empty($rowData['attributes']) ? null : $rowData['attributes'];
-                        $newRow = Row::create($rowData);
-                        // Set row ID in the row array
-                        $row['id'] = $newRow->id;
-                        // Update the row in the rows
-                        $this->rows[$lang]['rows'][$rowKey] = $row;
+                        $page->translations()->save(new PageTranslation(array_merge($trans, ['page_id' => $page->id])));
                     }
-                    //Update columns
-                    foreach (Arr::get($row, 'columns', []) as $columnKey => $column) {
-                        if (array_key_exists('id', $column)) {
-                            $newColumn = Column::find($column['id']);
-                            $newColumn->update($column);
+                }
+
+                foreach ($this->rows as $lang => $langRow) {
+                    $language = $languagesByLocale->get($lang);
+                    if (!$language) {
+                        continue;
+                    }
+
+                    foreach (Arr::get($langRow, 'rows', []) as $rowKey => $row) {
+                        $rowPayload = Arr::except($row, ['uuid']);
+                        $rowPayload['available_space'] = $this->calculateRowAvailableSpace(Arr::get($row, 'columns', []));
+                        $rowPayload['attributes'] = empty($rowPayload['attributes']) ? null : $rowPayload['attributes'];
+
+                        if (array_key_exists('id', $row)) {
+                            $newRow = Row::find($row['id']);
+                            $newRow->update($rowPayload);
                         } else {
-                            $newColumn = Column::create(array_merge($column, ['row_id' => $newRow->id]));
-                            // Set column ID in the column array
-                            $column['id'] = $newColumn->id;
-                            // Update the column in the rows
-                            $this->rows[$lang]['rows'][$rowKey]['columns'][$columnKey] = $column;
+                            $newRow = Row::create(array_merge($rowPayload, [
+                                'page_id' => $page->id,
+                                'language_id' => $language->id,
+                            ]));
+                            $row['id'] = $newRow->id;
+                            $this->rows[$lang]['rows'][$rowKey] = $row;
                         }
-                        //Update column items
-                        foreach (Arr::get($column, 'column_items', []) as $itemKey => $item) {
-                            if (array_key_exists('id', $item)) {
-                                $newColumnItem = ColumnItem::find($item['id']);
-                                $newColumnItem->update($item);
+
+                        foreach (Arr::get($row, 'columns', []) as $columnKey => $column) {
+                            if (array_key_exists('id', $column)) {
+                                $newColumn = Column::find($column['id']);
+                                $newColumn->update($column);
                             } else {
-                                $item = array_merge($item, ['column_id' => $newColumn->id]);
-                                $newColumnItem = ColumnItem::create(array_merge($item, ['column_id' => $newColumn->id]));
-                                // Set column item ID in the item array
-                                $item['id'] = $newColumnItem->id;
-                                // Update the column item in column
-                                $column['column_items'][$itemKey] = $item;
-                                // Update the column in the rows
+                                $newColumn = Column::create(array_merge($column, ['row_id' => $newRow->id]));
+                                $column['id'] = $newColumn->id;
                                 $this->rows[$lang]['rows'][$rowKey]['columns'][$columnKey] = $column;
+                            }
+
+                            foreach (Arr::get($column, 'column_items', []) as $itemKey => $item) {
+                                if (array_key_exists('id', $item)) {
+                                    ColumnItem::find($item['id'])->update($item);
+                                } else {
+                                    $newColumnItem = ColumnItem::create(array_merge($item, ['column_id' => $newColumn->id]));
+                                    $item['id'] = $newColumnItem->id;
+                                    $column['column_items'][$itemKey] = $item;
+                                    $this->rows[$lang]['rows'][$rowKey]['columns'][$columnKey] = $column;
+                                }
                             }
                         }
                     }
                 }
-            }
+            });
 
             session()->flash('message', 'Page successfully updated.');
 
             if ($redirect) {
                 return redirect()->route('page-composer::pages.index');
-            } else {
-                $this->dispatch('saved');
             }
 
+            $this->dispatch('saved');
             return;
         } catch (Exception $ex) {
+            report($ex);
             $this->showErrorMessage = true;
-            $this->exceptionMessage = $ex->getMessage() . ' ' . $ex->getLine() . ' ' . $ex->getFile();
+            $this->exceptionMessage = 'We could not update this page. Please try again.';
         }
     }
 

--- a/src/PageComposer/Livewire/PageComposer.php
+++ b/src/PageComposer/Livewire/PageComposer.php
@@ -27,7 +27,13 @@ class PageComposer extends Component
     #[Locked]
     public $elements;
 
-    public ?array $page = null;
+    /**
+     * Untyped because Livewire's nested-component machinery assigns the
+     * `page` route/attribute (an int id) to this property before mount()
+     * runs, then mount() rebuilds it as the page-state array via
+     * setPageContent(). Typing as ?array would reject the transient int.
+     */
+    public $page;
 
     #[Locked]
     public ?int $pageId = null;
@@ -310,8 +316,9 @@ class PageComposer extends Component
             $this->publishedOn = $page->published_on;
             //Get category
             $this->pageCategory = $page->category;
-            //Get tags
-            $this->pageTags = $page->tags;
+            // Tags ship as an array (matching the shape the tagsUpdated
+            // listener writes) so $pageTags has one stable shape.
+            $this->pageTags = $page->tags->toArray();
         } elseif (is_null($this->page)) {
             $this->page = [
                 'name' => null,

--- a/src/PageComposer/Livewire/PageComposer.php
+++ b/src/PageComposer/Livewire/PageComposer.php
@@ -8,19 +8,17 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\DB;
 use Flobbos\PageComposer\Models\Row;
 use Flobbos\PageComposer\Models\Tag;
 use Flobbos\PageComposer\Models\Page;
-use Flobbos\PageComposer\Models\Column;
 use Flobbos\PageComposer\Models\Element;
 use Flobbos\PageComposer\Models\Category;
 use Flobbos\PageComposer\Models\Language;
-use Flobbos\PageComposer\Models\ColumnItem;
 use Flobbos\PageComposer\Models\PageTemplate;
-use Flobbos\PageComposer\Models\PageTranslation;
 use Flobbos\PageComposer\Models\TagTranslation;
 use Flobbos\PageComposer\Models\CategoryTranslation;
+use Flobbos\PageComposer\Services\PageBuilder;
+use Flobbos\PageComposer\Services\PageBuilderResult;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Computed;
 
@@ -77,20 +75,6 @@ class PageComposer extends Component
         $this->page['slider_image'] = $this->slider_image;
         $this->page['published_on'] = $this->publishedOn;
         $this->page['category_id'] = Arr::get($this->pageCategory, 'id');
-    }
-
-    private function makePageModel(): Page
-    {
-        $page = $this->pageId ? Page::findOrFail($this->pageId) : new Page();
-
-        $page->name = Arr::get($this->page, 'name');
-        $page->photo = $this->photo;
-        $page->newsletter_image = $this->newsletter_image;
-        $page->slider_image = $this->slider_image;
-        $page->published_on = $this->publishedOn;
-        $page->category_id = Arr::get($this->pageCategory, 'id');
-
-        return $page;
     }
 
     public function mount($page = null)
@@ -362,64 +346,22 @@ class PageComposer extends Component
      */
     public function saveContent(bool $redirect)
     {
-
         $this->syncPageState();
-
         $this->validate();
 
         try {
-            $languagesByLocale = $this->getCachedLanguages()->keyBy('locale');
+            $result = $this->persistPage();
 
-            $page = DB::transaction(function () use ($languagesByLocale) {
-                $page = $this->makePageModel();
-                $page->save();
+            $this->pageId = $result->page->id;
+            $this->rows = $result->rows;
 
-                $page->tags()->sync(collect($this->pageTags)->pluck('id')->all());
-
-                foreach ($this->pageTranslations as $locale => $trans) {
-                    if (empty($trans['language_id'])) {
-                        continue;
-                    }
-                    $trans['slug'] = Str::slug(Arr::get($trans, 'content.title'));
-                    $page->translations()->save(new PageTranslation(array_merge($trans, ['page_id' => $page->id])));
-                }
-
-                foreach ($this->rows as $lang => $langRow) {
-                    $language = $languagesByLocale->get($lang);
-                    if (!$language) {
-                        continue;
-                    }
-
-                    foreach (Arr::get($langRow, 'rows', []) as $row) {
-                        $rowData = array_merge(Arr::except($row, ['uuid']), [
-                            'page_id' => $page->id,
-                            'language_id' => $language->id,
-                        ]);
-                        $rowData['attributes'] = empty($rowData['attributes']) ? null : $rowData['attributes'];
-                        $rowData['available_space'] = $this->calculateRowAvailableSpace(Arr::get($row, 'columns', []));
-                        $newRow = Row::create($rowData);
-
-                        foreach (Arr::get($row, 'columns', []) as $column) {
-                            $newColumn = Column::create(array_merge($column, ['row_id' => $newRow->id]));
-
-                            foreach (Arr::get($column, 'column_items', []) as $item) {
-                                ColumnItem::create(array_merge($item, ['column_id' => $newColumn->id]));
-                            }
-                        }
-                    }
-                }
-
-                return $page;
-            });
-
-            $this->pageId = $page->id;
             session()->flash('message', 'Page successfully saved.');
 
             if ($redirect) {
                 return redirect()->route('page-composer::pages.index');
             }
 
-            return redirect()->route('page-composer::pages.edit', $page->id);
+            return redirect()->route('page-composer::pages.edit', $result->page->id);
         } catch (Exception $ex) {
             report($ex);
             $this->showErrorMessage = true;
@@ -434,74 +376,13 @@ class PageComposer extends Component
     public function updateContent(bool $redirect)
     {
         $this->syncPageState();
-
         $this->validate();
 
         try {
-            $languagesByLocale = $this->getCachedLanguages()->keyBy('locale');
+            $result = $this->persistPage();
 
-            DB::transaction(function () use ($languagesByLocale) {
-                $page = $this->makePageModel();
-                $page->save();
-
-                $page->tags()->sync(collect($this->pageTags)->pluck('id')->all());
-
-                foreach ($this->pageTranslations as $locale => $trans) {
-                    $trans['slug'] = Str::slug(Arr::get($trans, 'content.title'));
-                    if (array_key_exists('id', $trans)) {
-                        PageTranslation::find($trans['id'])->update($trans);
-                    } else {
-                        $page->translations()->save(new PageTranslation(array_merge($trans, ['page_id' => $page->id])));
-                    }
-                }
-
-                foreach ($this->rows as $lang => $langRow) {
-                    $language = $languagesByLocale->get($lang);
-                    if (!$language) {
-                        continue;
-                    }
-
-                    foreach (Arr::get($langRow, 'rows', []) as $rowKey => $row) {
-                        $rowPayload = Arr::except($row, ['uuid']);
-                        $rowPayload['available_space'] = $this->calculateRowAvailableSpace(Arr::get($row, 'columns', []));
-                        $rowPayload['attributes'] = empty($rowPayload['attributes']) ? null : $rowPayload['attributes'];
-
-                        if (array_key_exists('id', $row)) {
-                            $newRow = Row::find($row['id']);
-                            $newRow->update($rowPayload);
-                        } else {
-                            $newRow = Row::create(array_merge($rowPayload, [
-                                'page_id' => $page->id,
-                                'language_id' => $language->id,
-                            ]));
-                            $row['id'] = $newRow->id;
-                            $this->rows[$lang]['rows'][$rowKey] = $row;
-                        }
-
-                        foreach (Arr::get($row, 'columns', []) as $columnKey => $column) {
-                            if (array_key_exists('id', $column)) {
-                                $newColumn = Column::find($column['id']);
-                                $newColumn->update($column);
-                            } else {
-                                $newColumn = Column::create(array_merge($column, ['row_id' => $newRow->id]));
-                                $column['id'] = $newColumn->id;
-                                $this->rows[$lang]['rows'][$rowKey]['columns'][$columnKey] = $column;
-                            }
-
-                            foreach (Arr::get($column, 'column_items', []) as $itemKey => $item) {
-                                if (array_key_exists('id', $item)) {
-                                    ColumnItem::find($item['id'])->update($item);
-                                } else {
-                                    $newColumnItem = ColumnItem::create(array_merge($item, ['column_id' => $newColumn->id]));
-                                    $item['id'] = $newColumnItem->id;
-                                    $column['column_items'][$itemKey] = $item;
-                                    $this->rows[$lang]['rows'][$rowKey]['columns'][$columnKey] = $column;
-                                }
-                            }
-                        }
-                    }
-                }
-            });
+            $this->pageId = $result->page->id;
+            $this->rows = $result->rows;
 
             session()->flash('message', 'Page successfully updated.');
 
@@ -516,6 +397,18 @@ class PageComposer extends Component
             $this->showErrorMessage = true;
             $this->exceptionMessage = 'We could not update this page. Please try again.';
         }
+    }
+
+    private function persistPage(): PageBuilderResult
+    {
+        return app(PageBuilder::class)->persist(
+            $this->pageId,
+            $this->page ?? [],
+            $this->pageTranslations,
+            $this->pageTags ?? [],
+            $this->rows,
+            $this->getCachedLanguages()->keyBy('locale'),
+        );
     }
 
     /**

--- a/src/PageComposer/Livewire/PageComposer.php
+++ b/src/PageComposer/Livewire/PageComposer.php
@@ -5,53 +5,40 @@ namespace Flobbos\PageComposer\Livewire;
 use Exception;
 use Livewire\Component;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Flobbos\PageComposer\Models\Row;
+use Flobbos\PageComposer\Livewire\Concerns\HandlesImageUploads;
+use Flobbos\PageComposer\Livewire\Concerns\HandlesTemplates;
+use Flobbos\PageComposer\Livewire\Concerns\InteractsWithLanguages;
+use Flobbos\PageComposer\Livewire\Concerns\ManagesRows;
 use Flobbos\PageComposer\Models\Page;
-use Flobbos\PageComposer\Models\Language;
 use Flobbos\PageComposer\Models\PageTemplate;
 use Flobbos\PageComposer\Services\PageBuilder;
 use Flobbos\PageComposer\Services\PageBuilderResult;
 use Flobbos\PageComposer\Services\PageComposerCache;
-use Flobbos\PageComposer\Services\SortService;
 use Livewire\Attributes\On;
-use Livewire\Attributes\Computed;
 
 class PageComposer extends Component
 {
-    //page
+    use HandlesImageUploads;
+    use HandlesTemplates;
+    use InteractsWithLanguages;
+    use ManagesRows;
+
     public $elements, $page, $pageId, $pageCategory;
     public $pageTags = [];
-
-    //language
-    public $languages, $currentLanguage, $availableLanguages, $selectableLanguages;
-
-    //photos
-    public $photo, $newsletter_image, $slider_image;
-
-    //options
     public $categories, $tags;
 
-    //error handling
     public $exceptionMessage;
     public $showErrorMessage = false;
 
-    //Settings
     public $settingsBox;
-    public $showMiniMap = false;
     public $currentElement = ['name' => ''];
 
-    //Preview
     public $previewMode = true;
     public $previewLanguage;
 
-    public $rows = [];
     public $pageTranslations = [];
 
     public $displayDate, $publishedOn;
-
-    //Template name
-    public $templateName, $selectedTemplate;
 
     protected function rules()
     {
@@ -112,134 +99,6 @@ class PageComposer extends Component
         ]);
 
         return Arr::get($sizes, $size, 'w-full');
-    }
-
-    /**
-     * Add a new language to the content
-     *
-     * @param integer $language_id
-     * @return void
-     */
-    public function addLanguage(int $language_id): void
-    {
-        $selectedLanguage = $this->cache()->languages()->firstWhere('id', $language_id) ?? Language::find($language_id);
-
-        if (!$selectedLanguage) {
-            return;
-        }
-
-        //Set current active language if not present
-        if (empty($this->currentLanguage)) {
-            $this->currentLanguage = $selectedLanguage;
-        }
-
-        //if (!$this->pageId) {
-        $this->pageTranslations[$selectedLanguage->locale]['language_id'] = $selectedLanguage->id;
-        $this->setRowsLanguage($selectedLanguage->id);
-        //}
-
-        $this->hydrateLanguages();
-    }
-
-    /**
-     * Set the current language for the content
-     *
-     * @param integer $language_id
-     * @return void
-     */
-    public function setLanguage(int $language_id): void
-    {
-        $this->currentLanguage = $this->cache()->languages()->firstWhere('id', $language_id) ?? Language::find($language_id);
-    }
-
-    /**
-     * Add a new row of content
-     *
-     * @return void
-     */
-    public function addRow(): void
-    {
-        $this->rows[$this->currentLanguage->locale]['rows'][] = [
-            'uuid' => (string) Str::uuid(),
-            'columns' => [],
-            'attributes' => [],
-            'alignment' => 'center',
-            'expanded' => false,
-            'active' => true,
-            'sorting' => $this->rows[$this->currentLanguage->locale]['rows'] ? count($this->rows[$this->currentLanguage->locale]['rows']) + 1 : 1,
-            'available_space' => 12
-        ];
-    }
-
-    /**
-     * Update the sorting for the rows. Called by Livewire 4's wire:sort when
-     * a row is dropped in a new position in the mini map.
-     *
-     * @param string|int $id       sortable key from wire:sort:item (uuid, db id, or tmp-N)
-     * @param int        $position zero-based target position
-     */
-    public function updateRowSorting($id, $position): void
-    {
-        $locale = $this->currentLanguage->locale ?? null;
-        if (!$locale) {
-            return;
-        }
-
-        $rows = $this->rows[$locale]['rows'] ?? [];
-
-        $this->rows[$locale]['rows'] = app(SortService::class)->reorder(
-            $rows,
-            fn(array $row, $key) => $this->rowSortableKey($row, (int) $key),
-            $id,
-            (int) $position,
-        );
-    }
-
-    public function rowSortableKey(array $row, int $fallbackIndex): string
-    {
-        if (filled(Arr::get($row, 'id'))) {
-            return (string) Arr::get($row, 'id');
-        }
-
-        if (filled(Arr::get($row, 'uuid'))) {
-            return (string) Arr::get($row, 'uuid');
-        }
-
-        return 'tmp-' . $fallbackIndex;
-    }
-
-    /**
-     * Computed property to get sorted rows
-     *
-     * @return array
-     */
-    #[Computed]
-    public function sortedRows(): array
-    {
-        if (!isset($this->currentLanguage)) {
-            return [];
-        }
-
-        if (empty($this->rows[$this->currentLanguage->locale]['rows'])) {
-            return [];
-        }
-
-        return Arr::sort($this->rows[$this->currentLanguage->locale]['rows'], function ($value) {
-            return $value['sorting'];
-        });
-    }
-
-    /**
-     * Sort column items
-     *
-     * @param array $items
-     * @return array
-     */
-    public function sortItems(array $items): array
-    {
-        return Arr::sort($items, function ($value) {
-            return $value['sorting'];
-        });
     }
 
     /**
@@ -312,109 +171,7 @@ class PageComposer extends Component
         );
     }
 
-    /**
-     * Copy all content from one language to another
-     *
-     * @param string $source source language
-     * @param string $target target language
-     * @return void
-     */
-    public function copyContent(string $source, string $target): void
-    {
-        $this->rows[$target] = $this->rows[$source];
-        //Remove database IDs from copied content
-        foreach ($this->rows[$target]['rows'] as $rowKey => $row) {
-            Arr::forget($this->rows, $target . '.rows.' . $rowKey . '.id');
-            $this->rows[$target]['rows'][$rowKey]['uuid'] = (string) Str::uuid();
-            foreach (Arr::get($row, 'columns', []) as $columnKey => $column) {
-                Arr::forget($this->rows, $target . '.rows.' . $rowKey . '.columns.' . $columnKey . '.id');
-                foreach (Arr::get($column, 'column_items', []) as $itemKey => $item) {
-                    Arr::forget($this->rows, $target . '.rows.' . $rowKey . '.columns.' . $columnKey . '.column_items.' . $itemKey . '.id');
-                }
-            }
-        }
-        $language = Language::where('locale', $target)->first();
-        $this->addLanguage($language->id);
-    }
-
-    /**
-     * Save current page as template
-     *
-     * @return void
-     */
-    public function saveTemplate(): void
-    {
-        $this->validate([
-            'templateName' => 'required'
-        ], ['required' => '(required)']);
-
-        //Set languages
-        $languages = [];
-
-        foreach ($this->pageTranslations as $trans) {
-            $languages[] = Arr::get($trans, 'language_id');
-        }
-
-        //Set content structure
-        $content = $this->rows;
-        foreach ($content as $langKey => $lang) {
-            foreach (Arr::get($lang, 'rows', []) as $key => $row) {
-                foreach (Arr::get($row, 'columns', []) as $columnKey => $column) {
-                    foreach (Arr::get($column, 'column_items', []) as $itemKey => $item) {
-                        $content[$langKey]['rows'][$key]['columns'][$columnKey]['column_items'][$itemKey]['content'] = [];
-                    }
-                }
-            }
-        }
-        //Create template
-        PageTemplate::create([
-            'name' => $this->templateName,
-            'content' => $content,
-            'languages' => $languages,
-            'user_id' => auth()->id()
-        ]);
-        $this->resetErrorBag();
-        $this->reset('templateName');
-        session()->flash('template_saved', '(saved)');
-    }
-
-    public function selectTemplate()
-    {
-        return redirect()->route('page-composer::pages.create', ['template' => $this->selectedTemplate]);
-    }
-
-    public function loadTemplate($templateId)
-    {
-        //Load template informaiton
-        $template = PageTemplate::find($templateId);
-        //Load languages
-        $languages = Language::whereIn('id', $template->languages)->get();
-        //Set page translations
-        foreach ($languages as $lang) {
-            $this->pageTranslations[$lang->locale] = [];
-            $this->addLanguage($lang->id);
-        }
-
-        //Set rows and columns
-        foreach ($template->content as $key => $rows) {
-            $this->rows[$key] = $rows;
-            $this->ensureUnsavedRowsHaveUuid($key);
-        }
-    }
-
     /******* Listeners *******/
-    /**
-     * Listener for when a new language has been added
-     *
-     * @return void
-     */
-    #[On('languageAdded')]
-    public function languageAdded(): void
-    {
-        // Language can be added during editing, so refresh this cache explicitly.
-        $this->cache()->languages(true);
-        $this->hydrateLanguages();
-    }
 
     /**
      * Refresh component list when a new one has been generated
@@ -451,37 +208,6 @@ class PageComposer extends Component
     {
         $this->pageCategory = $option;
         $this->page['category_id'] = Arr::get($option, 'id');
-    }
-
-    /**
-     * Event listener for when a row has been removed
-     *
-     * @param string $row_key
-     * @return void
-     */
-    #[On('deleteRow')]
-    public function deleteRow(string $rowKey): void
-    {
-        if (isset($this->rows[$this->currentLanguage->locale]['rows'][$rowKey]['id'])) {
-            if ($row = Row::find($this->rows[$this->currentLanguage->locale]['rows'][$rowKey]['id'])) {
-                $row->delete();
-            }
-        }
-        unset($this->rows[$this->currentLanguage->locale]['rows'][$rowKey]);
-    }
-
-    /**
-     * Event listener for an update to the row data
-     *
-     * @param array $row
-     * @param string $rowKey
-     * @return void
-     */
-    #[On('rowUpdated')]
-    #[On('columnUpdated')]
-    public function rowUpdated(array $row, string $rowKey): void
-    {
-        $this->rows[$this->currentLanguage->locale]['rows'][$rowKey] = $row;
     }
 
     /**
@@ -538,6 +264,7 @@ class PageComposer extends Component
                 $rowData['available_space'] = $this->calculateRowAvailableSpace(Arr::get($rowData, 'columns', []));
                 $this->rows[$row->language->locale]['rows'][] = $rowData;
             }
+
             //Set element data
             foreach ($this->rows as $lang => $langRow) {
                 foreach ($langRow['rows'] as $rowKey => $row) {
@@ -577,100 +304,4 @@ class PageComposer extends Component
         }
     }
 
-    /**
-     * Hydrate language specific arrays
-     *
-     * @return void
-     */
-    public function hydrateLanguages(): void
-    {
-        //All languages
-        $this->languages = $this->cache()->languages();
-        $this->availableLanguages = collect();
-        $this->selectableLanguages = $this->languages;
-        //Available languages in article
-
-        foreach ($this->pageTranslations as $trans) {
-            if (isset($trans['language_id'])) {
-                $this->availableLanguages->push($this->languages->where('id', $trans['language_id'])->first());
-            }
-        }
-
-        //Languages that can be added
-        foreach ($this->selectableLanguages as $key => $lang) {
-            if ($this->availableLanguages->contains('id', $lang->id)) {
-                $this->selectableLanguages->forget($key);
-            }
-        }
-    }
-
-    /**
-     * Set current language for the rows
-     *
-     * @param integer $language_id
-     * @return void
-     */
-    public function setRowsLanguage(int $language_id)
-    {
-        $lang = $this->cache()->languages()->firstWhere('id', $language_id) ?? Language::find($language_id);
-
-        if (!$lang) {
-            return;
-        }
-
-        if (! isset($this->rows[$lang->locale])) {
-            $this->rows[$lang->locale] = [
-                'rows' => [],
-            ];
-        }
-
-        $this->ensureUnsavedRowsHaveUuid($lang->locale);
-    }
-
-    private function ensureUnsavedRowsHaveUuid(string $locale): void
-    {
-        foreach (Arr::get($this->rows, $locale . '.rows', []) as $rowKey => $row) {
-            $this->rows[$locale]['rows'][$rowKey]['available_space'] = $this->calculateRowAvailableSpace(Arr::get($row, 'columns', []));
-
-            if (filled(Arr::get($row, 'id')) || filled(Arr::get($row, 'uuid'))) {
-                continue;
-            }
-
-            $this->rows[$locale]['rows'][$rowKey]['uuid'] = (string) Str::uuid();
-        }
-    }
-
-    private function calculateRowAvailableSpace(array $columns): int
-    {
-        return max(0, 12 - (int) collect($columns)
-            ->sum(fn($column) => (int) Arr::get($column, 'column_size', 0)));
-    }
-
-    private const PHOTO_FIELDS = ['photo', 'newsletter_image', 'slider_image'];
-
-    #[On('eventImageUploadComponentSaved.pageComposer.mainPhoto')]
-    #[On('eventImageUploadComponentSaved.pageComposer.newsletterImage')]
-    #[On('eventImageUploadComponentSaved.pageComposer.sliderImage')]
-    public function imageSaved(string $field, string $imagePath, ?int $itemIndex = null): void
-    {
-        $this->setPhotoField($field, $imagePath);
-    }
-
-    #[On('eventImageUploadComponentDeleted.pageComposer.mainPhoto')]
-    #[On('eventImageUploadComponentDeleted.pageComposer.newsletterImage')]
-    #[On('eventImageUploadComponentDeleted.pageComposer.sliderImage')]
-    public function imageDeleted(string $field, ?string $imagePath = null, ?int $itemIndex = null): void
-    {
-        $this->setPhotoField($field, null);
-    }
-
-    private function setPhotoField(string $field, ?string $value): void
-    {
-        if (!in_array($field, self::PHOTO_FIELDS, true)) {
-            return;
-        }
-
-        $this->{$field} = $value;
-        $this->page[$field] = $value;
-    }
 }

--- a/src/PageComposer/Livewire/PageComposer.php
+++ b/src/PageComposer/Livewire/PageComposer.php
@@ -13,6 +13,7 @@ use Flobbos\PageComposer\Models\PageTemplate;
 use Flobbos\PageComposer\Services\PageBuilder;
 use Flobbos\PageComposer\Services\PageBuilderResult;
 use Flobbos\PageComposer\Services\PageComposerCache;
+use Flobbos\PageComposer\Services\SortService;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Computed;
 
@@ -185,39 +186,13 @@ class PageComposer extends Component
         }
 
         $rows = $this->rows[$locale]['rows'] ?? [];
-        if (empty($rows)) {
-            return;
-        }
 
-        $indexByKey = [];
-        foreach ($rows as $index => $row) {
-            $indexByKey[$this->rowSortableKey($row, $index)] = $index;
-        }
-
-        $sourceKey = (string) $id;
-        if (!array_key_exists($sourceKey, $indexByKey)) {
-            return;
-        }
-
-        $orderedIndices = collect($rows)
-            ->map(fn($row, $index) => ['index' => $index, 'sorting' => (int) Arr::get($row, 'sorting', 0)])
-            ->sortBy('sorting')
-            ->pluck('index')
-            ->values()
-            ->all();
-
-        $sourceIndex = $indexByKey[$sourceKey];
-        $currentPosition = array_search($sourceIndex, $orderedIndices, true);
-        if ($currentPosition === false) {
-            return;
-        }
-
-        array_splice($orderedIndices, $currentPosition, 1);
-        array_splice($orderedIndices, max(0, (int) $position), 0, $sourceIndex);
-
-        foreach ($orderedIndices as $newPosition => $rowIndex) {
-            $this->rows[$locale]['rows'][$rowIndex]['sorting'] = $newPosition + 1;
-        }
+        $this->rows[$locale]['rows'] = app(SortService::class)->reorder(
+            $rows,
+            fn(array $row, $key) => $this->rowSortableKey($row, (int) $key),
+            $id,
+            (int) $position,
+        );
     }
 
     public function rowSortableKey(array $row, int $fallbackIndex): string

--- a/src/PageComposer/Livewire/PageComposer.php
+++ b/src/PageComposer/Livewire/PageComposer.php
@@ -14,6 +14,7 @@ use Flobbos\PageComposer\Models\PageTemplate;
 use Flobbos\PageComposer\Services\PageBuilder;
 use Flobbos\PageComposer\Services\PageBuilderResult;
 use Flobbos\PageComposer\Services\PageComposerCache;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 
 class PageComposer extends Component
@@ -23,22 +24,39 @@ class PageComposer extends Component
     use InteractsWithLanguages;
     use ManagesRows;
 
-    public $elements, $page, $pageId, $pageCategory;
-    public $pageTags = [];
-    public $categories, $tags;
+    #[Locked]
+    public $elements;
 
-    public $exceptionMessage;
-    public $showErrorMessage = false;
+    public ?array $page = null;
 
-    public $settingsBox;
-    public $currentElement = ['name' => ''];
+    #[Locked]
+    public ?int $pageId = null;
 
-    public $previewMode = true;
+    public $pageCategory;
+    public array $pageTags = [];
+
+    #[Locked]
+    public $categories;
+
+    #[Locked]
+    public $tags;
+
+    #[Locked]
+    public ?string $exceptionMessage = null;
+
+    #[Locked]
+    public bool $showErrorMessage = false;
+
+    public ?string $settingsBox = null;
+    public array $currentElement = ['name' => ''];
+
+    public bool $previewMode = true;
     public $previewLanguage;
 
-    public $pageTranslations = [];
+    public array $pageTranslations = [];
 
-    public $displayDate, $publishedOn;
+    public ?string $displayDate = null;
+    public $publishedOn;
 
     protected function rules()
     {

--- a/src/PageComposer/Livewire/PageComposer.php
+++ b/src/PageComposer/Livewire/PageComposer.php
@@ -671,45 +671,31 @@ class PageComposer extends Component
             ->sum(fn($column) => (int) Arr::get($column, 'column_size', 0)));
     }
 
-    #[On('eventImageUploadComponentDeleted.pageComposer.mainPhoto')]
-    public function handleImageUploadComponentDeletedPageComposerMainPhoto($imagePath, $itemIndex)
-    {
-        $this->photo = null;
-        $this->page['photo'] = null;
-    }
+    private const PHOTO_FIELDS = ['photo', 'newsletter_image', 'slider_image'];
 
     #[On('eventImageUploadComponentSaved.pageComposer.mainPhoto')]
-    public function handleImageUploadComponentSavedPageComposerMainPhoto($imagePath, $itemIndex)
-    {
-        $this->photo = $imagePath;
-        $this->page['photo'] = $imagePath;
-    }
-
-    #[On('eventImageUploadComponentDeleted.pageComposer.newsletterImage')]
-    public function handleImageUploadComponentDeletedPageComposerNewsletterImage($imagePath, $itemIndex)
-    {
-        $this->newsletter_image = null;
-        $this->page['newsletter_image'] = null;
-    }
-
     #[On('eventImageUploadComponentSaved.pageComposer.newsletterImage')]
-    public function handleImageUploadComponentSavedPageComposerNewsletterImage($imagePath, $itemIndex)
-    {
-        $this->newsletter_image = $imagePath;
-        $this->page['newsletter_image'] = $imagePath;
-    }
-
-    #[On('eventImageUploadComponentDeleted.pageComposer.sliderImage')]
-    public function handleImageUploadComponentDeletedPageComposerSliderImage($imagePath, $itemIndex)
-    {
-        $this->slider_image = null;
-        $this->page['slider_image'] = null;
-    }
-
     #[On('eventImageUploadComponentSaved.pageComposer.sliderImage')]
-    public function handleImageUploadComponentSavedPageComposerSliderImage($imagePath, $itemIndex)
+    public function imageSaved(string $field, string $imagePath, ?int $itemIndex = null): void
     {
-        $this->slider_image = $imagePath;
-        $this->page['slider_image'] = $imagePath;
+        $this->setPhotoField($field, $imagePath);
+    }
+
+    #[On('eventImageUploadComponentDeleted.pageComposer.mainPhoto')]
+    #[On('eventImageUploadComponentDeleted.pageComposer.newsletterImage')]
+    #[On('eventImageUploadComponentDeleted.pageComposer.sliderImage')]
+    public function imageDeleted(string $field, ?string $imagePath = null, ?int $itemIndex = null): void
+    {
+        $this->setPhotoField($field, null);
+    }
+
+    private function setPhotoField(string $field, ?string $value): void
+    {
+        if (!in_array($field, self::PHOTO_FIELDS, true)) {
+            return;
+        }
+
+        $this->{$field} = $value;
+        $this->page[$field] = $value;
     }
 }

--- a/src/PageComposer/Livewire/RowComponent.php
+++ b/src/PageComposer/Livewire/RowComponent.php
@@ -4,20 +4,25 @@ namespace Flobbos\PageComposer\Livewire;
 
 use Flobbos\PageComposer\Models\Column;
 use Flobbos\PageComposer\Services\SortService;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Modelable;
 use Livewire\Component;
 use Illuminate\Support\Arr;
-use Livewire\Attributes\Computed;
-use Livewire\Attributes\On;
 
 class RowComponent extends Component
 {
+    /**
+     * Bound to the parent's $rows[locale][rows][rowKey] via wire:model.
+     * Mutations propagate up automatically; no dispatch chain needed.
+     */
+    #[Modelable]
     public $row;
-    public $rowKey, $previewMode;
-    public $source;
+
+    public $rowKey;
+    public $previewMode;
 
     public function mount()
     {
-        $this->source = $this->id();
         $this->syncAvailableSpace();
     }
 
@@ -57,8 +62,6 @@ class RowComponent extends Component
         ];
 
         $this->syncAvailableSpace();
-
-        $this->dispatch('columnUpdated', row: $this->row, rowKey: $this->rowKey);
     }
 
     #[Computed]
@@ -183,20 +186,9 @@ class RowComponent extends Component
                 $column->delete();
             }
         }
-        $size = $this->row['columns'][$columnKey]['column_size'];
         unset($this->row['columns'][$columnKey]);
         $this->row['columns'] = array_values($this->row['columns']);
         $this->syncAvailableSpace();
-
-        $this->dispatch('columnUpdated', row: $this->row, rowKey: $this->rowKey);
-    }
-
-    #[On('itemsUpdated.{source}')]
-    public function itemsUpdated(array $column, int $columnKey)
-    {
-        $this->row['columns'][$columnKey] = $column;
-
-        $this->dispatch('columnUpdated', row: $this->row, rowKey: $this->rowKey);
     }
 
     #[Computed]
@@ -229,14 +221,11 @@ class RowComponent extends Component
         }
 
         $this->row['columns'] = $reordered;
-
-        $this->dispatch('columnUpdated', row: $this->row, rowKey: $this->rowKey);
     }
 
     public function saveRowSettings()
     {
         $this->syncAvailableSpace();
-        $this->dispatch('rowUpdated', row: $this->row, rowKey: $this->rowKey);
     }
 
     private function syncAvailableSpace(): void

--- a/src/PageComposer/Livewire/RowComponent.php
+++ b/src/PageComposer/Livewire/RowComponent.php
@@ -2,7 +2,6 @@
 
 namespace Flobbos\PageComposer\Livewire;
 
-use Flobbos\PageComposer\Models\Column;
 use Flobbos\PageComposer\Services\SortService;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Modelable;
@@ -179,13 +178,14 @@ class RowComponent extends Component
             ->all();
     }
 
+    /**
+     * Stage a column removal in component state. The column (and any of
+     * its column items) is only removed from the DB when the page is
+     * saved, via PageBuilder's orphan purge. A refresh before save
+     * therefore restores the column.
+     */
     public function deleteColumn($columnKey)
     {
-        if (isset($this->row['columns'][$columnKey]['id'])) {
-            if ($column = Column::find($this->row['columns'][$columnKey]['id'])) {
-                $column->delete();
-            }
-        }
         unset($this->row['columns'][$columnKey]);
         $this->row['columns'] = array_values($this->row['columns']);
         $this->syncAvailableSpace();

--- a/src/PageComposer/Livewire/RowComponent.php
+++ b/src/PageComposer/Livewire/RowComponent.php
@@ -3,6 +3,7 @@
 namespace Flobbos\PageComposer\Livewire;
 
 use Flobbos\PageComposer\Models\Column;
+use Flobbos\PageComposer\Services\SortService;
 use Livewire\Component;
 use Illuminate\Support\Arr;
 use Livewire\Attributes\Computed;
@@ -215,33 +216,19 @@ class RowComponent extends Component
     public function updateColumnOrder($id, $position)
     {
         $columns = Arr::get($this->row, 'columns', []);
-        if (empty($columns)) {
+
+        $reordered = app(SortService::class)->reorder(
+            $columns,
+            fn(array $col, $key) => (string) $key,
+            $id,
+            (int) $position,
+        );
+
+        if ($reordered === $columns) {
             return;
         }
 
-        $sourceIndex = $id;
-        if (!array_key_exists($sourceIndex, $columns)) {
-            return;
-        }
-
-        $orderedIndices = collect($columns)
-            ->map(fn($col, $index) => ['index' => $index, 'sorting' => (int) Arr::get($col, 'sorting', 0)])
-            ->sortBy('sorting')
-            ->pluck('index')
-            ->values()
-            ->all();
-
-        $currentPosition = array_search($sourceIndex, $orderedIndices, true);
-        if ($currentPosition === false) {
-            return;
-        }
-
-        array_splice($orderedIndices, $currentPosition, 1);
-        array_splice($orderedIndices, max(0, (int) $position), 0, $sourceIndex);
-
-        foreach ($orderedIndices as $newPosition => $colIndex) {
-            $this->row['columns'][$colIndex]['sorting'] = $newPosition + 1;
-        }
+        $this->row['columns'] = $reordered;
 
         $this->dispatch('columnUpdated', row: $this->row, rowKey: $this->rowKey);
     }

--- a/src/PageComposer/PageComposerServiceProvider.php
+++ b/src/PageComposer/PageComposerServiceProvider.php
@@ -5,51 +5,59 @@ namespace Flobbos\PageComposer;
 
 use Livewire\Livewire;
 use Illuminate\Support\Facades\Blade;
-use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Facades\Validator;
-use Flobbos\PageComposer\Livewire\PageIndex;
-use Flobbos\PageComposer\Livewire\DatePicker;
-use Flobbos\PageComposer\Livewire\ElementList;
-use Flobbos\PageComposer\Livewire\MultiSelect;
-use Flobbos\PageComposer\Livewire\SelectInput;
+use Illuminate\Support\Str;
 use Flobbos\PageComposer\Livewire\BugComponent;
-use Flobbos\PageComposer\Livewire\PageComposer;
-use Flobbos\PageComposer\Livewire\RowComponent;
-use Flobbos\PageComposer\Livewire\TagComponent;
+use Flobbos\PageComposer\Livewire\CategoryComponent;
 use Flobbos\PageComposer\Livewire\ColumnComponent;
 use Flobbos\PageComposer\Livewire\CommentComponent;
+use Flobbos\PageComposer\Livewire\DatePicker;
 use Flobbos\PageComposer\Livewire\ElementComponent;
-use Flobbos\PageComposer\Livewire\MultiSelectInput;
-use Flobbos\PageComposer\Livewire\CategoryComponent;
+use Flobbos\PageComposer\Livewire\ElementList;
+use Flobbos\PageComposer\Livewire\ImageUploadComponent;
 use Flobbos\PageComposer\Livewire\LanguageComponent;
+use Flobbos\PageComposer\Livewire\MultiSelect;
+use Flobbos\PageComposer\Livewire\MultiSelectInput;
+use Flobbos\PageComposer\Livewire\PageComposer;
+use Flobbos\PageComposer\Livewire\PageIndex;
+use Flobbos\PageComposer\Livewire\RowComponent;
+use Flobbos\PageComposer\Livewire\SelectInput;
+use Flobbos\PageComposer\Livewire\TagComponent;
 use Flobbos\PageComposer\Livewire\TemplateComponent;
 use Flobbos\PageComposer\View\Components\BaseElement;
-use Flobbos\PageComposer\Livewire\ImageUploadComponent;
 
 class PageComposerServiceProvider extends ServiceProvider
 {
+  /**
+   * Livewire components shipped by this package. Each one is registered
+   * under the kebab-cased class basename, matching Livewire 4's default
+   * tag convention (BugComponent -> <livewire:bug-component />).
+   */
+  private const LIVEWIRE_COMPONENTS = [
+    BugComponent::class,
+    CategoryComponent::class,
+    ColumnComponent::class,
+    CommentComponent::class,
+    DatePicker::class,
+    ElementComponent::class,
+    ElementList::class,
+    ImageUploadComponent::class,
+    LanguageComponent::class,
+    MultiSelect::class,
+    MultiSelectInput::class,
+    PageComposer::class,
+    PageIndex::class,
+    RowComponent::class,
+    SelectInput::class,
+    TagComponent::class,
+    TemplateComponent::class,
+  ];
 
   public function boot(): void
   {
-    //Register components
-    Livewire::component('bug-component', BugComponent::class);
-    Livewire::component('category-component', CategoryComponent::class);
-    Livewire::component('column-component', ColumnComponent::class);
-    Livewire::component('comment-component', CommentComponent::class);
-    Livewire::component('element-component', ElementComponent::class);
-    Livewire::component('element-list', ElementList::class);
-    Livewire::component('date-picker', DatePicker::class);
-    Livewire::component('image-upload-component', ImageUploadComponent::class);
-    Livewire::component('language-component', LanguageComponent::class);
-    Livewire::component('multi-select', MultiSelect::class);
-    Livewire::component('multi-select-input', MultiSelectInput::class);
-    Livewire::component('page-composer', PageComposer::class);
-    Livewire::component('page-index', PageIndex::class);
-    Livewire::component('row-component', RowComponent::class);
-    Livewire::component('select-input', SelectInput::class);
-    Livewire::component('tag-component', TagComponent::class);
-    Livewire::component('template-component', TemplateComponent::class);
+    foreach (self::LIVEWIRE_COMPONENTS as $componentClass) {
+      Livewire::component(Str::kebab(class_basename($componentClass)), $componentClass);
+    }
 
     //Blade components
     Blade::component('page-composer::base-element', BaseElement::class);

--- a/src/PageComposer/Services/PageBuilder.php
+++ b/src/PageComposer/Services/PageBuilder.php
@@ -31,6 +31,8 @@ class PageBuilder
 
             $rows = $this->upsertRows($page, $rows, $languagesByLocale);
 
+            $this->purgeOrphans($page, $rows, $languagesByLocale);
+
             return new PageBuilderResult($page, $rows);
         });
     }
@@ -126,5 +128,74 @@ class PageBuilder
     {
         return max(0, 12 - (int) collect($columns)
             ->sum(fn($column) => (int) Arr::get($column, 'column_size', 0)));
+    }
+
+    /**
+     * Delete rows / columns / column items that exist in the database for
+     * this page but were dropped from the in-memory state since load.
+     * Structural deletes are staged in the editor (no immediate DB
+     * delete) and applied here on save. Runs inside the transaction so
+     * the purge rolls back if anything else fails.
+     */
+    private function purgeOrphans(Page $page, array $rows, Collection $languagesByLocale): void
+    {
+        foreach ($rows as $locale => $langRow) {
+            $language = $languagesByLocale->get($locale);
+            if (!$language) {
+                continue;
+            }
+
+            $keptRowIds = collect(Arr::get($langRow, 'rows', []))
+                ->pluck('id')
+                ->filter()
+                ->values();
+
+            $orphanedRows = Row::where('page_id', $page->id)
+                ->where('language_id', $language->id);
+
+            if ($keptRowIds->isNotEmpty()) {
+                $orphanedRows->whereNotIn('id', $keptRowIds);
+            }
+
+            $orphanedRows->delete();
+
+            foreach (Arr::get($langRow, 'rows', []) as $row) {
+                if (!array_key_exists('id', $row)) {
+                    continue;
+                }
+
+                $keptColumnIds = collect(Arr::get($row, 'columns', []))
+                    ->pluck('id')
+                    ->filter()
+                    ->values();
+
+                $orphanedColumns = Column::where('row_id', $row['id']);
+
+                if ($keptColumnIds->isNotEmpty()) {
+                    $orphanedColumns->whereNotIn('id', $keptColumnIds);
+                }
+
+                $orphanedColumns->delete();
+
+                foreach (Arr::get($row, 'columns', []) as $column) {
+                    if (!array_key_exists('id', $column)) {
+                        continue;
+                    }
+
+                    $keptItemIds = collect(Arr::get($column, 'column_items', []))
+                        ->pluck('id')
+                        ->filter()
+                        ->values();
+
+                    $orphanedItems = ColumnItem::where('column_id', $column['id']);
+
+                    if ($keptItemIds->isNotEmpty()) {
+                        $orphanedItems->whereNotIn('id', $keptItemIds);
+                    }
+
+                    $orphanedItems->delete();
+                }
+            }
+        }
     }
 }

--- a/src/PageComposer/Services/PageBuilder.php
+++ b/src/PageComposer/Services/PageBuilder.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Flobbos\PageComposer\Services;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Flobbos\PageComposer\Models\Column;
+use Flobbos\PageComposer\Models\ColumnItem;
+use Flobbos\PageComposer\Models\Page;
+use Flobbos\PageComposer\Models\PageTranslation;
+use Flobbos\PageComposer\Models\Row;
+
+class PageBuilder
+{
+    public function persist(
+        ?int $pageId,
+        array $pageData,
+        array $pageTranslations,
+        array $pageTags,
+        array $rows,
+        Collection $languagesByLocale,
+    ): PageBuilderResult {
+        return DB::transaction(function () use ($pageId, $pageData, $pageTranslations, $pageTags, $rows, $languagesByLocale) {
+            $page = $this->upsertPage($pageId, $pageData);
+
+            $page->tags()->sync(collect($pageTags)->pluck('id')->all());
+
+            $this->upsertTranslations($page, $pageTranslations);
+
+            $rows = $this->upsertRows($page, $rows, $languagesByLocale);
+
+            return new PageBuilderResult($page, $rows);
+        });
+    }
+
+    private function upsertPage(?int $pageId, array $pageData): Page
+    {
+        $page = $pageId ? Page::findOrFail($pageId) : new Page();
+
+        $page->name = Arr::get($pageData, 'name');
+        $page->photo = Arr::get($pageData, 'photo');
+        $page->newsletter_image = Arr::get($pageData, 'newsletter_image');
+        $page->slider_image = Arr::get($pageData, 'slider_image');
+        $page->published_on = Arr::get($pageData, 'published_on');
+        $page->category_id = Arr::get($pageData, 'category_id');
+        $page->save();
+
+        return $page;
+    }
+
+    private function upsertTranslations(Page $page, array $translations): void
+    {
+        foreach ($translations as $trans) {
+            if (empty($trans['language_id'])) {
+                continue;
+            }
+
+            $trans['slug'] = Str::slug(Arr::get($trans, 'content.title'));
+
+            if (array_key_exists('id', $trans)) {
+                PageTranslation::find($trans['id'])?->update($trans);
+                continue;
+            }
+
+            $page->translations()->save(new PageTranslation(array_merge($trans, ['page_id' => $page->id])));
+        }
+    }
+
+    private function upsertRows(Page $page, array $rows, Collection $languagesByLocale): array
+    {
+        foreach ($rows as $locale => $langRow) {
+            $language = $languagesByLocale->get($locale);
+            if (!$language) {
+                continue;
+            }
+
+            foreach (Arr::get($langRow, 'rows', []) as $rowKey => $row) {
+                $rowPayload = Arr::except($row, ['uuid']);
+                $rowPayload['available_space'] = $this->calculateAvailableSpace(Arr::get($row, 'columns', []));
+                $rowPayload['attributes'] = empty($rowPayload['attributes']) ? null : $rowPayload['attributes'];
+
+                if (array_key_exists('id', $row)) {
+                    $rowModel = Row::find($row['id']);
+                    $rowModel->update($rowPayload);
+                } else {
+                    $rowModel = Row::create(array_merge($rowPayload, [
+                        'page_id' => $page->id,
+                        'language_id' => $language->id,
+                    ]));
+                    $row['id'] = $rowModel->id;
+                    $rows[$locale]['rows'][$rowKey] = $row;
+                }
+
+                foreach (Arr::get($row, 'columns', []) as $columnKey => $column) {
+                    if (array_key_exists('id', $column)) {
+                        Column::find($column['id'])?->update($column);
+                        $columnId = $column['id'];
+                    } else {
+                        $columnModel = Column::create(array_merge($column, ['row_id' => $rowModel->id]));
+                        $column['id'] = $columnModel->id;
+                        $columnId = $columnModel->id;
+                        $rows[$locale]['rows'][$rowKey]['columns'][$columnKey] = $column;
+                    }
+
+                    foreach (Arr::get($column, 'column_items', []) as $itemKey => $item) {
+                        if (array_key_exists('id', $item)) {
+                            ColumnItem::find($item['id'])?->update($item);
+                            continue;
+                        }
+
+                        $itemModel = ColumnItem::create(array_merge($item, ['column_id' => $columnId]));
+                        $item['id'] = $itemModel->id;
+                        $column['column_items'][$itemKey] = $item;
+                        $rows[$locale]['rows'][$rowKey]['columns'][$columnKey] = $column;
+                    }
+                }
+            }
+        }
+
+        return $rows;
+    }
+
+    private function calculateAvailableSpace(array $columns): int
+    {
+        return max(0, 12 - (int) collect($columns)
+            ->sum(fn($column) => (int) Arr::get($column, 'column_size', 0)));
+    }
+}

--- a/src/PageComposer/Services/PageBuilderResult.php
+++ b/src/PageComposer/Services/PageBuilderResult.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Flobbos\PageComposer\Services;
+
+use Flobbos\PageComposer\Models\Page;
+
+final readonly class PageBuilderResult
+{
+    public function __construct(
+        public Page $page,
+        public array $rows,
+    ) {}
+}

--- a/src/PageComposer/Services/PageComposerCache.php
+++ b/src/PageComposer/Services/PageComposerCache.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Flobbos\PageComposer\Services;
+
+use Flobbos\PageComposer\Models\Category;
+use Flobbos\PageComposer\Models\CategoryTranslation;
+use Flobbos\PageComposer\Models\Element;
+use Flobbos\PageComposer\Models\Language;
+use Flobbos\PageComposer\Models\Tag;
+use Flobbos\PageComposer\Models\TagTranslation;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+class PageComposerCache
+{
+    private const KEY_ELEMENTS = 'page-composer.elements';
+    private const KEY_LANGUAGES = 'page-composer.languages';
+    private const KEY_CATEGORIES = 'page-composer.categories';
+    private const KEY_TAGS = 'page-composer.tags';
+
+    private const TTL_DEFAULT_MINUTES = 30;
+    private const TTL_LANGUAGES_MINUTES = 5;
+
+    public function elements(bool $refresh = false): Collection
+    {
+        return $this->remember(
+            self::KEY_ELEMENTS,
+            self::TTL_DEFAULT_MINUTES,
+            $refresh,
+            fn() => Element::all()->toArray(),
+            fn(array $cached) => Element::hydrate($cached),
+        );
+    }
+
+    public function languages(bool $refresh = false): Collection
+    {
+        return $this->remember(
+            self::KEY_LANGUAGES,
+            self::TTL_LANGUAGES_MINUTES,
+            $refresh,
+            fn() => Language::all()->toArray(),
+            fn(array $cached) => Language::hydrate($cached),
+        );
+    }
+
+    public function categories(bool $refresh = false): Collection
+    {
+        return $this->remember(
+            self::KEY_CATEGORIES,
+            self::TTL_DEFAULT_MINUTES,
+            $refresh,
+            fn() => Category::with('translations')->get()->toArray(),
+            fn(array $cached) => $this->hydrateWithTranslations(Category::class, CategoryTranslation::class, $cached),
+        );
+    }
+
+    public function tags(bool $refresh = false): Collection
+    {
+        return $this->remember(
+            self::KEY_TAGS,
+            self::TTL_DEFAULT_MINUTES,
+            $refresh,
+            fn() => Tag::with('translations')->get()->toArray(),
+            fn(array $cached) => $this->hydrateWithTranslations(Tag::class, TagTranslation::class, $cached),
+        );
+    }
+
+    public function forgetAll(): void
+    {
+        foreach ([self::KEY_ELEMENTS, self::KEY_LANGUAGES, self::KEY_CATEGORIES, self::KEY_TAGS] as $key) {
+            Cache::forget($key);
+        }
+    }
+
+    /**
+     * Caching arrays (rather than Eloquent Collections) avoids
+     * serialize/unserialize fragility across framework upgrades and
+     * cache driver changes; the hydrator rebuilds models on read.
+     */
+    private function remember(string $key, int $ttlMinutes, bool $refresh, callable $loader, callable $hydrator): Collection
+    {
+        if ($refresh) {
+            Cache::forget($key);
+        }
+
+        $cached = Cache::remember($key, now()->addMinutes($ttlMinutes), $loader);
+
+        return $hydrator($cached);
+    }
+
+    private function hydrateWithTranslations(string $modelClass, string $translationClass, array $cached): Collection
+    {
+        return collect($cached)->map(function (array $row) use ($modelClass, $translationClass) {
+            $translations = Arr::pull($row, 'translations', []);
+            $model = $modelClass::hydrate([$row])->first();
+            $model->setRelation('translations', $translationClass::hydrate($translations));
+            return $model;
+        });
+    }
+}

--- a/src/PageComposer/Services/SortService.php
+++ b/src/PageComposer/Services/SortService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Flobbos\PageComposer\Services;
+
+use Illuminate\Support\Arr;
+
+class SortService
+{
+    /**
+     * Move the item identified by $sourceKey to the zero-based
+     * $position and rewrite each item's `sorting` key to a 1-based
+     * contiguous sequence reflecting the new order. Original array
+     * keys are preserved.
+     *
+     * Returns the input untouched if $items is empty or $sourceKey
+     * cannot be resolved, so callers can detect a no-op via ===.
+     *
+     * @param callable $keyResolver fn(mixed $item, mixed $itemKey): string
+     */
+    public function reorder(array $items, callable $keyResolver, string|int $sourceKey, int $position): array
+    {
+        if (empty($items)) {
+            return $items;
+        }
+
+        $indexByKey = [];
+        foreach ($items as $itemKey => $item) {
+            $indexByKey[(string) $keyResolver($item, $itemKey)] = $itemKey;
+        }
+
+        $sourceKey = (string) $sourceKey;
+        if (!array_key_exists($sourceKey, $indexByKey)) {
+            return $items;
+        }
+
+        $orderedKeys = collect($items)
+            ->map(fn($item, $itemKey) => ['key' => $itemKey, 'sorting' => (int) Arr::get($item, 'sorting', 0)])
+            ->sortBy('sorting')
+            ->pluck('key')
+            ->values()
+            ->all();
+
+        $sourceItemKey = $indexByKey[$sourceKey];
+        $currentPosition = array_search($sourceItemKey, $orderedKeys, true);
+        if ($currentPosition === false) {
+            return $items;
+        }
+
+        array_splice($orderedKeys, $currentPosition, 1);
+        array_splice($orderedKeys, max(0, $position), 0, [$sourceItemKey]);
+
+        foreach ($orderedKeys as $newPosition => $itemKey) {
+            $items[$itemKey]['sorting'] = $newPosition + 1;
+        }
+
+        return $items;
+    }
+}

--- a/src/config/pagecomposer.php
+++ b/src/config/pagecomposer.php
@@ -12,12 +12,12 @@ return [
      * Define the minimum required information
      */
     'rules' => [
-        'page.name' => 'required', //mandatory
-        'page.photo' => 'required',
-        'page.slider_image' => 'sometimes:image',
-        'page.newsletter_image' => 'sometimes:image',
+        'pageData.name' => 'required', //mandatory
+        'pageData.photo' => 'required',
+        'pageData.slider_image' => 'sometimes:image',
+        'pageData.newsletter_image' => 'sometimes:image',
         'pageTranslations.*.content.title' => 'required', //mandatory
-        'page.category_id' => 'required', //remove if not using categories
+        'pageData.category_id' => 'required', //remove if not using categories
     ],
 
     /**

--- a/src/config/pagecomposer.php
+++ b/src/config/pagecomposer.php
@@ -47,6 +47,16 @@ return [
     'middleware' => 'auth:sanctum',
 
     /**
+     * Date format used by the built-in date picker, both for the value
+     * shown to the user and for the value dispatched/parsed when a date
+     * is selected.
+     *
+     * Default keeps backwards compatibility with previous releases.
+     * Recommended for new installs: 'Y-m-d' (ISO 8601, locale-neutral).
+     */
+    'date_format' => 'm-d-Y',
+
+    /**
      * Person responsible for the bug component
      * Provide the user id
      */

--- a/src/resources/views/components/settings/general.blade.php
+++ b/src/resources/views/components/settings/general.blade.php
@@ -14,7 +14,7 @@
 
             <div class="col-span-6 sm:col-span-3">
                 <label for="page_title" class="block mb-2 text-xs font-medium text-gray-700">{{ __('Title (internal)') }}</label>
-                <input type="text" name="name" id="page_title" wire:model.lazy="page.name" autocomplete="given-name"
+                <input type="text" name="name" id="page_title" wire:model.lazy="pageData.name" autocomplete="given-name"
                     class="block w-full h-12 px-5 mt-1 transition duration-300 border-gray-300 shadow-sm bg-gray-50 focus:bg-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-xl">
             </div>
 

--- a/src/resources/views/components/settings/media.blade.php
+++ b/src/resources/views/components/settings/media.blade.php
@@ -9,12 +9,12 @@
 
     <x-slot name="content">
         <div class="flex flex-col gap-4">
-            <livewire:image-upload-component existingImage="{{ $photo }}" eventTarget="pageComposer.mainPhoto" imagePath="photos/" key="upload-main-photo" title="Main Photo" />
+            <livewire:image-upload-component existingImage="{{ $photo }}" eventTarget="pageComposer.mainPhoto" fieldName="photo" imagePath="photos/" key="upload-main-photo" title="Main Photo" />
 
             <div class="flex gap-4">
-                <livewire:image-upload-component class="w-1/2" existingImage="{{ $sliderImage }}" eventTarget="pageComposer.sliderImage" imagePath="photos/" key="upload-slider-photo" title="Slider Photo" />
+                <livewire:image-upload-component class="w-1/2" existingImage="{{ $sliderImage }}" eventTarget="pageComposer.sliderImage" fieldName="slider_image" imagePath="photos/" key="upload-slider-photo" title="Slider Photo" />
 
-                <livewire:image-upload-component class="w-1/2" existingImage="{{ $newsletterImage }}" eventTarget="pageComposer.newsletterImage" imagePath="photos/" key="upload-newsletter-photo" title="Newsletter Photo" />
+                <livewire:image-upload-component class="w-1/2" existingImage="{{ $newsletterImage }}" eventTarget="pageComposer.newsletterImage" fieldName="newsletter_image" imagePath="photos/" key="upload-newsletter-photo" title="Newsletter Photo" />
             </div>
         </div>
     </x-slot>

--- a/src/resources/views/livewire/column-component.blade.php
+++ b/src/resources/views/livewire/column-component.blade.php
@@ -4,8 +4,9 @@
         title="Remove column">
         <x-heroicon-o-x-mark class="w-4 h-4" />
     </button>
-    <div class="absolute z-10 w-32 p-2 text-xs bg-white rounded-lg shadow-md -right-2 top-4" x-cloak x-show="showConfirm" @click.away="showConfirm = false">
-        {{ __('Delete this column?') }}
+    <div class="absolute z-10 w-36 p-2 text-xs bg-white rounded-lg shadow-md -right-2 top-4" x-cloak x-show="showConfirm" @click.away="showConfirm = false">
+        <p>{{ __('Remove this column?') }}</p>
+        <p class="pt-1 text-gray-500">{{ __('Applied when you save the page.') }}</p>
         <div class="flex justify-between pt-2">
             <button class="px-2 text-white bg-red-600 rounded hover:bg-red-700" type="button" wire:click="$parent.deleteColumn({{ $columnKey }})">{{ __('Yes') }}</button>
             <button class="px-2 text-white bg-green-600 rounded hover:bg-green-700" type="button" @click="showConfirm = false">{{ __('No') }}</button>

--- a/src/resources/views/livewire/page-composer.blade.php
+++ b/src/resources/views/livewire/page-composer.blade.php
@@ -393,7 +393,7 @@
                     @if (!$availableLanguages->isEmpty())
                         @forelse($this->sortedRows as $rowKey=>$row)
                             <div wire:key="{{ $currentLanguage->locale }}-row-wrapper-{{ $rowKey }}">
-                                <livewire:row-component :key="$currentLanguage->locale . '-row-' . $rowKey . '-' . ($previewMode ? 'preview' : 'schema')" :row="$row" :rowKey="$rowKey" :previewMode="$previewMode" />
+                                <livewire:row-component :key="$currentLanguage->locale . '-row-' . $rowKey . '-' . ($previewMode ? 'preview' : 'schema')" wire:model="rows.{{ $currentLanguage->locale }}.rows.{{ $rowKey }}" :rowKey="$rowKey" :previewMode="$previewMode" />
                             </div>
                         @empty
                             <div class="mb-5 text-gray-600 duration-500 border-2 border-dashed rounded-xl">

--- a/src/resources/views/livewire/page-composer.blade.php
+++ b/src/resources/views/livewire/page-composer.blade.php
@@ -285,7 +285,7 @@
 
                 <div class="flex items-center px-5 space-x-1 text-2xl font-semibold font-title">
                     @if ($previewMode)
-                        <span>{{ Arr::get($page, 'name', __('Content')) }}</span>
+                        <span>{{ Arr::get($pageData, 'name', __('Content')) }}</span>
                     @else
                         <span>{{ __('Schema') }}</span>
                     @endif

--- a/src/resources/views/livewire/row-component.blade.php
+++ b/src/resources/views/livewire/row-component.blade.php
@@ -87,7 +87,7 @@
     <div wire:sort="updateColumnOrder" class="flex space-x-4 justify-left transition pt-0 @if (count($row['columns']) > 0) pt-4 @endif">
         @foreach ($this->sortedColumns as $columnKey => $column)
             <div wire:key="row-{{ $rowKey }}-col-{{ $columnKey }}" wire:sort:item="{{ $columnKey }}" class="{{ $this->columnWidth($column['column_size']) }}">
-                <livewire:column-component :column="$column" :key="$source . '-col-' . $columnKey . '-' . ($previewMode ? 'preview' : 'schema')" :columnKey="$columnKey" :previewMode="$previewMode" target="{{ $source }}" />
+                <livewire:column-component wire:model="row.columns.{{ $columnKey }}" :key="'row-' . $rowKey . '-col-' . $columnKey . '-' . ($previewMode ? 'preview' : 'schema')" :columnKey="$columnKey" :previewMode="$previewMode" />
             </div>
         @endforeach
     </div>

--- a/src/resources/views/livewire/row-component.blade.php
+++ b/src/resources/views/livewire/row-component.blade.php
@@ -17,8 +17,9 @@
                 <button class="p-1 text-red-800 transition bg-red-200 rounded-full group-hover:shadow-md hover:bg-red-400 hover:text-red-100 focus:outline-none" @click="showConfirm = ! showConfirm" title="Remove row">
                     <x-heroicon-o-trash class="w-4 h-4 stroke-current" />
                 </button>
-                <div class="absolute z-10 p-2 text-xs bg-white rounded-lg shadow-md w-28 -left-2 top-8" x-cloak x-show="showConfirm" @click.away="showConfirm = false">
-                    {{ __('Delete this row?') }}
+                <div class="absolute z-10 p-2 text-xs bg-white rounded-lg shadow-md w-36 -left-2 top-8" x-cloak x-show="showConfirm" @click.away="showConfirm = false">
+                    <p>{{ __('Remove this row?') }}</p>
+                    <p class="pt-1 text-gray-500">{{ __('Applied when you save the page.') }}</p>
                     <div class="flex justify-between pt-2">
                         <button class="px-2 text-white bg-red-600 rounded hover:bg-red-700" type="button" wire:click="$dispatch('deleteRow', {rowKey: {{ $rowKey }}})">{{ __('Yes') }}</button>
                         <button class="px-2 text-white bg-green-600 rounded hover:bg-green-700" type="button" @click="showConfirm = false">{{ __('No') }}</button>

--- a/tests/Feature/ColumnComponentTest.php
+++ b/tests/Feature/ColumnComponentTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use Flobbos\PageComposer\Livewire\ColumnComponent;
+use Livewire\Livewire;
+
+function emptyColumn(int $size = 6): array
+{
+    return [
+        'column_items' => [],
+        'column_size' => $size,
+        'attributes' => [],
+        'sorting' => 1,
+        'active' => true,
+    ];
+}
+
+function elementItem(string $name, string $component, int $sorting): array
+{
+    return [
+        'element_id' => 1,
+        'name' => $name,
+        'icon' => '<svg></svg>',
+        'component' => $component,
+        'attributes' => [],
+        'sorting' => $sorting,
+        'active' => true,
+        'content' => [],
+    ];
+}
+
+it('appends an element when elementAdded is dispatched', function () {
+    $element = seedElement('Text', 'text');
+
+    $component = Livewire::test(ColumnComponent::class, [
+        'column' => emptyColumn(),
+        'columnKey' => 0,
+        'previewMode' => false,
+    ]);
+
+    $sourceId = $component->get('source');
+
+    $component->dispatch('elementAdded.' . $sourceId, element: $element->id);
+
+    $items = $component->get('column.column_items');
+
+    expect($items)->toHaveCount(1)
+        ->and($items[0]['component'])->toBe('text')
+        ->and($items[0]['sorting'])->toBe(1);
+});
+
+it('sorts an element down in a single action and exposes fresh state to the view', function () {
+    $column = emptyColumn();
+    $column['column_items'] = [
+        elementItem('A', 'text', 1),
+        elementItem('B', 'text', 2),
+        elementItem('C', 'text', 3),
+    ];
+
+    $component = Livewire::test(ColumnComponent::class, [
+        'column' => $column,
+        'columnKey' => 0,
+        'previewMode' => false,
+    ])->call('sortElementDown', 0);
+
+    $items = $component->get('column.column_items');
+
+    expect($items[0]['sorting'])->toBe(2)
+        ->and($items[1]['sorting'])->toBe(1)
+        ->and($items[2]['sorting'])->toBe(3);
+});
+
+it('sorts an element up in a single action', function () {
+    $column = emptyColumn();
+    $column['column_items'] = [
+        elementItem('A', 'text', 1),
+        elementItem('B', 'text', 2),
+        elementItem('C', 'text', 3),
+    ];
+
+    $component = Livewire::test(ColumnComponent::class, [
+        'column' => $column,
+        'columnKey' => 0,
+        'previewMode' => false,
+    ])->call('sortElementUp', 2);
+
+    $items = $component->get('column.column_items');
+
+    expect($items[0]['sorting'])->toBe(1)
+        ->and($items[1]['sorting'])->toBe(3)
+        ->and($items[2]['sorting'])->toBe(2);
+});
+
+it('removes an element and re-numbers remaining items', function () {
+    $column = emptyColumn();
+    $column['column_items'] = [
+        elementItem('A', 'text', 1),
+        elementItem('B', 'text', 2),
+        elementItem('C', 'text', 3),
+    ];
+
+    $component = Livewire::test(ColumnComponent::class, [
+        'column' => $column,
+        'columnKey' => 0,
+        'previewMode' => false,
+    ])->call('deleteElement', 1);
+
+    $items = $component->get('column.column_items');
+
+    expect($items)->toHaveCount(2)
+        ->and($items[0]['sorting'])->toBe(1)
+        ->and($items[0]['name'])->toBe('A')
+        ->and($items[2]['sorting'])->toBe(2)
+        ->and($items[2]['name'])->toBe('C');
+});
+
+it('computes arrow visibility via getElementPositionArray', function () {
+    $column = emptyColumn();
+    $column['column_items'] = [
+        elementItem('A', 'text', 1),
+        elementItem('B', 'text', 2),
+        elementItem('C', 'text', 3),
+    ];
+
+    $component = Livewire::test(ColumnComponent::class, [
+        'column' => $column,
+        'columnKey' => 0,
+        'previewMode' => false,
+    ]);
+
+    $top = $component->instance()->getElementPositionArray(0);
+    $middle = $component->instance()->getElementPositionArray(1);
+    $bottom = $component->instance()->getElementPositionArray(2);
+
+    expect($top)->toEqual(['up' => false, 'down' => true, 'position' => 1])
+        ->and($middle)->toEqual(['up' => true, 'down' => true, 'position' => 2])
+        ->and($bottom)->toEqual(['up' => true, 'down' => false, 'position' => 3]);
+});

--- a/tests/Feature/DeferredDeleteTest.php
+++ b/tests/Feature/DeferredDeleteTest.php
@@ -1,0 +1,180 @@
+<?php
+
+use Flobbos\PageComposer\Livewire\ColumnComponent;
+use Flobbos\PageComposer\Livewire\PageComposer;
+use Flobbos\PageComposer\Livewire\RowComponent;
+use Flobbos\PageComposer\Models\Category;
+use Flobbos\PageComposer\Models\Column;
+use Flobbos\PageComposer\Models\ColumnItem;
+use Flobbos\PageComposer\Models\Language;
+use Flobbos\PageComposer\Models\Page;
+use Flobbos\PageComposer\Models\PageTranslation;
+use Flobbos\PageComposer\Models\Row;
+use Livewire\Livewire;
+
+function makeEditablePage(): Page
+{
+    seedLanguages(['en']);
+    $element = seedElement();
+    $english = Language::where('locale', 'en')->first();
+    $category = Category::create([]);
+
+    $page = new Page();
+    $page->name = 'Editable Page';
+    $page->photo = 'cover.jpg';
+    $page->category_id = $category->id;
+    $page->save();
+
+    PageTranslation::create([
+        'page_id' => $page->id,
+        'language_id' => $english->id,
+        'slug' => 'editable-page',
+        'content' => ['title' => 'Editable Page'],
+    ]);
+
+    $row = Row::create([
+        'page_id' => $page->id,
+        'language_id' => $english->id,
+        'alignment' => 'center',
+        'attributes' => null,
+        'expanded' => false,
+        'active' => true,
+        'sorting' => 1,
+        'available_space' => 0,
+    ]);
+
+    $column = Column::create([
+        'row_id' => $row->id,
+        'column_size' => 12,
+        'attributes' => null,
+        'sorting' => 1,
+        'active' => true,
+    ]);
+
+    ColumnItem::create([
+        'column_id' => $column->id,
+        'element_id' => $element->id,
+        'sorting' => 1,
+        'active' => true,
+        'attributes' => null,
+        'content' => ['text' => 'hello'],
+    ]);
+
+    return $page->fresh();
+}
+
+it('stages row removal in memory without deleting from the database', function () {
+    $page = makeEditablePage();
+
+    expect(Row::count())->toBe(1);
+
+    Livewire::test(PageComposer::class, ['page' => $page->id])
+        ->call('deleteRow', 0);
+
+    expect(Row::count())->toBe(1);
+});
+
+it('deletes removed rows from the database when the page is saved', function () {
+    $page = makeEditablePage();
+    $rowId = Row::value('id');
+
+    Livewire::test(PageComposer::class, ['page' => $page->id])
+        ->call('deleteRow', 0)
+        ->call('updateContent', false)
+        ->assertHasNoErrors()
+        ->assertSet('showErrorMessage', false);
+
+    expect(Row::whereKey($rowId)->exists())->toBeFalse();
+});
+
+it('restores removed rows after a refresh before save', function () {
+    $page = makeEditablePage();
+
+    Livewire::test(PageComposer::class, ['page' => $page->id])
+        ->call('deleteRow', 0);
+
+    $component = Livewire::test(PageComposer::class, ['page' => $page->id]);
+
+    expect($component->get('rows.en.rows'))->toHaveCount(1)
+        ->and(Row::count())->toBe(1);
+});
+
+it('stages column removal until the page is saved', function () {
+    $page = makeEditablePage();
+    $row = $page->rows()->with('columns.column_items.element')->first();
+    $columnId = $row->columns->first()->id;
+
+    $rowState = $row->toArray();
+    $rowState['columns'] = $row->columns->map(function ($column) {
+        $data = $column->toArray();
+        $data['column_items'] = $column->column_items->map(fn ($item) => [
+            'element_id' => $item->element->id,
+            'id' => $item->id,
+            'name' => $item->element->name,
+            'component' => $item->element->component,
+            'icon' => $item->element->icon,
+            'content' => $item->content,
+            'attributes' => $item->attributes,
+            'sorting' => $item->sorting,
+            'active' => $item->active,
+        ])->all();
+
+        return $data;
+    })->all();
+
+    Livewire::test(RowComponent::class, [
+        'row' => $rowState,
+        'rowKey' => 0,
+        'previewMode' => false,
+    ])->call('deleteColumn', 0);
+
+    expect(Column::whereKey($columnId)->exists())->toBeTrue();
+});
+
+it('stages element removal until the page is saved', function () {
+    $page = makeEditablePage();
+    $column = $page->rows()->first()->columns()->with('column_items.element')->first();
+    $item = $column->column_items->first();
+
+    $columnState = $column->toArray();
+    $columnState['column_items'] = [
+        0 => [
+            'element_id' => $item->element->id,
+            'id' => $item->id,
+            'name' => $item->element->name,
+            'component' => $item->element->component,
+            'icon' => $item->element->icon,
+            'content' => $item->content,
+            'attributes' => $item->attributes,
+            'sorting' => $item->sorting,
+            'active' => $item->active,
+        ],
+    ];
+
+    Livewire::test(ColumnComponent::class, [
+        'column' => $columnState,
+        'columnKey' => 0,
+        'previewMode' => false,
+    ])->call('deleteElement', 0);
+
+    expect(ColumnItem::whereKey($item->id)->exists())->toBeTrue();
+});
+
+it('purges removed columns when the page is saved', function () {
+    $page = makeEditablePage();
+    $columnId = Column::value('id');
+
+    $component = Livewire::test(PageComposer::class, ['page' => $page->id]);
+    $rows = $component->get('rows');
+    $rows['en']['rows'][0]['columns'] = [];
+    $rows['en']['rows'][0]['available_space'] = 12;
+
+    $component
+        ->set('rows', $rows)
+        ->call('updateContent', false)
+        ->assertHasNoErrors()
+        ->assertSet('showErrorMessage', false);
+
+    expect(Column::whereKey($columnId)->exists())->toBeFalse()
+        ->and(Row::count())->toBe(1);
+});

--- a/tests/Feature/HarnessTest.php
+++ b/tests/Feature/HarnessTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Flobbos\PageComposer\Models\Language;
+use Flobbos\PageComposer\Models\Element;
+
+it('boots the package service provider', function () {
+    expect(config('pagecomposer'))->toBeArray()
+        ->and(config('pagecomposer.bug_user'))->toBe(1);
+});
+
+it('runs package migrations against an in-memory sqlite db', function () {
+    $language = Language::create([
+        'name' => 'English',
+        'locale' => 'en',
+    ]);
+
+    expect($language->exists)->toBeTrue()
+        ->and(Language::count())->toBe(1);
+});
+
+it('can seed languages and elements via test helpers', function () {
+    seedLanguages(['en', 'de', 'fr']);
+    seedElement('Text', 'text');
+
+    expect(Language::pluck('locale')->all())->toEqual(['en', 'de', 'fr'])
+        ->and(Element::where('component', 'text')->exists())->toBeTrue();
+});

--- a/tests/Feature/PageBuilderTest.php
+++ b/tests/Feature/PageBuilderTest.php
@@ -1,0 +1,324 @@
+<?php
+
+use Flobbos\PageComposer\Models\Category;
+use Flobbos\PageComposer\Models\Column;
+use Flobbos\PageComposer\Models\ColumnItem;
+use Flobbos\PageComposer\Models\Page;
+use Flobbos\PageComposer\Models\PageTranslation;
+use Flobbos\PageComposer\Models\Row;
+use Flobbos\PageComposer\Models\Tag;
+use Flobbos\PageComposer\Services\PageBuilder;
+
+beforeEach(function () {
+    $this->builder = new PageBuilder();
+    $this->languages = seedLanguages(['en', 'de'])->keyBy('locale');
+    $this->element = seedElement('Text', 'text');
+    $this->category = Category::create([]);
+});
+
+function buildBaseState(\Flobbos\PageComposer\Models\Element $element, int $categoryId): array
+{
+    return [
+        'pageData' => [
+            'name' => 'Hello',
+            'photo' => null,
+            'newsletter_image' => null,
+            'slider_image' => null,
+            'published_on' => null,
+            'category_id' => $categoryId,
+        ],
+        'translations' => [
+            'en' => [
+                'language_id' => 1,
+                'content' => ['title' => 'Hello'],
+            ],
+        ],
+        'rows' => [
+            'en' => [
+                'rows' => [
+                    [
+                        'uuid' => 'tmp-1',
+                        'sorting' => 1,
+                        'alignment' => 'center',
+                        'expanded' => false,
+                        'active' => true,
+                        'attributes' => [],
+                        'columns' => [
+                            [
+                                'sorting' => 1,
+                                'column_size' => 6,
+                                'active' => true,
+                                'attributes' => [],
+                                'column_items' => [
+                                    [
+                                        'element_id' => $element->id,
+                                        'sorting' => 1,
+                                        'active' => true,
+                                        'attributes' => [],
+                                        'content' => ['body' => 'Lorem ipsum'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+}
+
+it('creates a new Page when pageId is null', function () {
+    $state = buildBaseState($this->element, $this->category->id);
+
+    $result = $this->builder->persist(
+        null,
+        $state['pageData'],
+        $state['translations'],
+        [],
+        $state['rows'],
+        $this->languages,
+    );
+
+    expect($result->page)->toBeInstanceOf(Page::class);
+    expect($result->page->id)->not->toBeNull();
+    expect($result->page->name)->toBe('Hello');
+    expect(Page::count())->toBe(1);
+});
+
+it('updates an existing Page when pageId is given', function () {
+    $page = new Page();
+    $page->name = 'Original';
+    $page->category_id = $this->category->id;
+    $page->save();
+    $state = buildBaseState($this->element, $this->category->id);
+    $state['pageData']['name'] = 'Updated';
+
+    $result = $this->builder->persist(
+        $page->id,
+        $state['pageData'],
+        $state['translations'],
+        [],
+        $state['rows'],
+        $this->languages,
+    );
+
+    expect($result->page->id)->toBe($page->id);
+    expect(Page::count())->toBe(1);
+    expect($page->fresh()->name)->toBe('Updated');
+});
+
+it('persists translations on insert path', function () {
+    $state = buildBaseState($this->element, $this->category->id);
+
+    $result = $this->builder->persist(
+        null,
+        $state['pageData'],
+        $state['translations'],
+        [],
+        $state['rows'],
+        $this->languages,
+    );
+
+    expect(PageTranslation::count())->toBe(1);
+    $translation = PageTranslation::first();
+    expect($translation->page_id)->toBe($result->page->id);
+    expect($translation->language_id)->toBe(1);
+    expect($translation->slug)->toBe('hello');
+});
+
+it('updates an existing translation when its id is supplied', function () {
+    $page = new Page();
+    $page->name = 'Existing';
+    $page->category_id = $this->category->id;
+    $page->save();
+    $existing = $page->translations()->create([
+        'language_id' => 1,
+        'content' => ['title' => 'Old'],
+        'slug' => 'old',
+    ]);
+
+    $state = buildBaseState($this->element, $this->category->id);
+    $state['translations']['en']['id'] = $existing->id;
+    $state['translations']['en']['content'] = ['title' => 'Brand New'];
+
+    $this->builder->persist(
+        $page->id,
+        $state['pageData'],
+        $state['translations'],
+        [],
+        $state['rows'],
+        $this->languages,
+    );
+
+    expect(PageTranslation::count())->toBe(1);
+    expect($existing->fresh()->slug)->toBe('brand-new');
+});
+
+it('skips translations without a language_id', function () {
+    $state = buildBaseState($this->element, $this->category->id);
+    $state['translations']['de'] = ['content' => ['title' => 'Hallo']];
+
+    $this->builder->persist(
+        null,
+        $state['pageData'],
+        $state['translations'],
+        [],
+        $state['rows'],
+        $this->languages,
+    );
+
+    expect(PageTranslation::count())->toBe(1);
+});
+
+it('syncs page tags', function () {
+    seedLanguages(['en']);
+    $tagA = Tag::create([]);
+    $tagB = Tag::create([]);
+
+    $state = buildBaseState($this->element, $this->category->id);
+
+    $result = $this->builder->persist(
+        null,
+        $state['pageData'],
+        $state['translations'],
+        [['id' => $tagA->id], ['id' => $tagB->id]],
+        $state['rows'],
+        $this->languages,
+    );
+
+    expect($result->page->tags->pluck('id')->all())->toEqualCanonicalizing([$tagA->id, $tagB->id]);
+});
+
+it('persists rows, columns, and items on the insert path', function () {
+    $state = buildBaseState($this->element, $this->category->id);
+
+    $this->builder->persist(
+        null,
+        $state['pageData'],
+        $state['translations'],
+        [],
+        $state['rows'],
+        $this->languages,
+    );
+
+    expect(Row::count())->toBe(1);
+    expect(Column::count())->toBe(1);
+    expect(ColumnItem::count())->toBe(1);
+
+    $row = Row::first();
+    expect($row->language_id)->toBe(1);
+    expect($row->available_space)->toBe(6);
+});
+
+it('returns rows with newly assigned IDs filled in', function () {
+    $state = buildBaseState($this->element, $this->category->id);
+
+    $result = $this->builder->persist(
+        null,
+        $state['pageData'],
+        $state['translations'],
+        [],
+        $state['rows'],
+        $this->languages,
+    );
+
+    $row = $result->rows['en']['rows'][0];
+    expect($row['id'])->toBe(Row::first()->id);
+    expect($row['columns'][0]['id'])->toBe(Column::first()->id);
+    expect($row['columns'][0]['column_items'][0]['id'])->toBe(ColumnItem::first()->id);
+});
+
+it('updates existing rows / columns / items when their ids are present', function () {
+    $state = buildBaseState($this->element, $this->category->id);
+
+    $first = $this->builder->persist(
+        null,
+        $state['pageData'],
+        $state['translations'],
+        [],
+        $state['rows'],
+        $this->languages,
+    );
+
+    // Take the result, mutate the body content, persist again as an update.
+    $rows = $first->rows;
+    $rows['en']['rows'][0]['columns'][0]['column_items'][0]['content'] = ['body' => 'Edited'];
+
+    $this->builder->persist(
+        $first->page->id,
+        $state['pageData'],
+        $state['translations'],
+        [],
+        $rows,
+        $this->languages,
+    );
+
+    expect(Row::count())->toBe(1);
+    expect(Column::count())->toBe(1);
+    expect(ColumnItem::count())->toBe(1);
+    expect(ColumnItem::first()->content)->toBe(['body' => 'Edited']);
+});
+
+it('rolls back the entire persist when something inside fails', function () {
+    $state = buildBaseState($this->element, $this->category->id);
+    // column_items.content is NOT NULL; force the inner insert to fail.
+    $state['rows']['en']['rows'][0]['columns'][0]['column_items'][0]['content'] = null;
+
+    $caught = null;
+    try {
+        $this->builder->persist(
+            null,
+            $state['pageData'],
+            $state['translations'],
+            [],
+            $state['rows'],
+            $this->languages,
+        );
+    } catch (\Throwable $ex) {
+        $caught = $ex;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect(Page::count())->toBe(0);
+    expect(Row::count())->toBe(0);
+    expect(Column::count())->toBe(0);
+    expect(ColumnItem::count())->toBe(0);
+});
+
+it('skips locales that have no matching language', function () {
+    $state = buildBaseState($this->element, $this->category->id);
+    $state['rows']['fr'] = $state['rows']['en'];
+
+    $this->builder->persist(
+        null,
+        $state['pageData'],
+        $state['translations'],
+        [],
+        $state['rows'],
+        $this->languages,
+    );
+
+    expect(Row::count())->toBe(1);
+});
+
+it('computes available_space as 12 minus the sum of column sizes', function () {
+    $state = buildBaseState($this->element, $this->category->id);
+    $state['rows']['en']['rows'][0]['columns'][] = [
+        'sorting' => 2,
+        'column_size' => 3,
+        'active' => true,
+        'attributes' => [],
+        'column_items' => [],
+    ];
+
+    $this->builder->persist(
+        null,
+        $state['pageData'],
+        $state['translations'],
+        [],
+        $state['rows'],
+        $this->languages,
+    );
+
+    expect(Row::first()->available_space)->toBe(3);
+});

--- a/tests/Feature/PageComposerCacheTest.php
+++ b/tests/Feature/PageComposerCacheTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use Flobbos\PageComposer\Models\Category;
+use Flobbos\PageComposer\Models\Element;
+use Flobbos\PageComposer\Models\Tag;
+use Flobbos\PageComposer\Services\PageComposerCache;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function () {
+    Cache::flush();
+    $this->cache = app(PageComposerCache::class);
+});
+
+it('hydrates cached elements as Element models', function () {
+    seedElement('Text', 'text');
+    seedElement('Photo', 'photo');
+
+    $elements = $this->cache->elements();
+
+    expect($elements)->toHaveCount(2);
+    expect($elements->first())->toBeInstanceOf(Element::class);
+    expect($elements->pluck('component')->all())->toEqualCanonicalizing(['text', 'photo']);
+});
+
+it('serves the second call from cache', function () {
+    seedElement('Text', 'text');
+
+    $first = $this->cache->elements();
+
+    Element::create(['name' => 'Photo', 'component' => 'photo', 'icon' => '<svg></svg>']);
+
+    $second = $this->cache->elements();
+
+    expect($second)->toHaveCount($first->count());
+});
+
+it('refreshes when called with refresh=true', function () {
+    seedElement('Text', 'text');
+    $this->cache->elements();
+
+    Element::create(['name' => 'Photo', 'component' => 'photo', 'icon' => '<svg></svg>']);
+
+    expect($this->cache->elements(true))->toHaveCount(2);
+});
+
+it('hydrates languages as Language models', function () {
+    seedLanguages(['en', 'de', 'fr']);
+
+    $languages = $this->cache->languages();
+
+    expect($languages)->toHaveCount(3);
+    expect($languages->pluck('locale')->all())->toEqualCanonicalizing(['en', 'de', 'fr']);
+});
+
+it('hydrates categories with their translations relation restored', function () {
+    seedLanguages(['en']);
+    $category = Category::create([]);
+    $category->translations()->create([
+        'language_id' => 1,
+        'name' => 'News',
+        'slug' => 'news',
+    ]);
+
+    $categories = $this->cache->categories();
+
+    expect($categories)->toHaveCount(1);
+    expect($categories->first()->translations)->toHaveCount(1);
+    expect($categories->first()->translations->first()->name)->toBe('News');
+});
+
+it('hydrates tags with their translations relation restored', function () {
+    seedLanguages(['en']);
+    $tag = Tag::create([]);
+    $tag->translations()->create([
+        'language_id' => 1,
+        'name' => 'Featured',
+        'slug' => 'featured',
+    ]);
+
+    $tags = $this->cache->tags();
+
+    expect($tags)->toHaveCount(1);
+    expect($tags->first()->translations->first()->name)->toBe('Featured');
+});
+
+it('forgets all four cache keys', function () {
+    seedElement('Text', 'text');
+    seedLanguages(['en']);
+
+    $this->cache->elements();
+    $this->cache->languages();
+    $this->cache->categories();
+    $this->cache->tags();
+
+    expect(Cache::has('page-composer.elements'))->toBeTrue();
+    expect(Cache::has('page-composer.languages'))->toBeTrue();
+    expect(Cache::has('page-composer.categories'))->toBeTrue();
+    expect(Cache::has('page-composer.tags'))->toBeTrue();
+
+    $this->cache->forgetAll();
+
+    expect(Cache::has('page-composer.elements'))->toBeFalse();
+    expect(Cache::has('page-composer.languages'))->toBeFalse();
+    expect(Cache::has('page-composer.categories'))->toBeFalse();
+    expect(Cache::has('page-composer.tags'))->toBeFalse();
+});

--- a/tests/Feature/PageComposerComponentTest.php
+++ b/tests/Feature/PageComposerComponentTest.php
@@ -25,7 +25,7 @@ beforeEach(function () {
 function pageState(int $categoryId, int $elementId): array
 {
     return [
-        'page' => [
+        'pageData' => [
             'name' => 'Hello',
             'photo' => 'photos/hello.jpg',
             'newsletter_image' => null,
@@ -79,8 +79,8 @@ function pageState(int $categoryId, int $elementId): array
 it('mounts with a default page array when no id is provided', function () {
     Livewire::test(PageComposer::class)
         ->assertSet('pageId', null)
-        ->assertSet('page.name', null)
-        ->assertSet('page.photo', null);
+        ->assertSet('pageData.name', null)
+        ->assertSet('pageData.photo', null);
 });
 
 it('hydrates from the DB when mounted with an existing page id', function () {
@@ -97,15 +97,15 @@ it('hydrates from the DB when mounted with an existing page id', function () {
 
     Livewire::test(PageComposer::class, ['page' => $page->id])
         ->assertSet('pageId', $page->id)
-        ->assertSet('page.name', 'Existing')
-        ->assertSet('page.photo', 'photos/existing.jpg')
+        ->assertSet('pageData.name', 'Existing')
+        ->assertSet('pageData.photo', 'photos/existing.jpg')
         ->assertSet('photo', 'photos/existing.jpg');
 });
 
 it('blocks saveContent when required fields are missing', function () {
     Livewire::test(PageComposer::class)
         ->call('saveContent', false)
-        ->assertHasErrors(['page.name', 'page.photo', 'page.category_id']);
+        ->assertHasErrors(['pageData.name', 'pageData.photo', 'pageData.category_id']);
 
     expect(Page::count())->toBe(0);
 });
@@ -116,8 +116,8 @@ it('persists through saveContent on the happy path', function () {
 
     $component = Livewire::test(PageComposer::class)
         ->call('addLanguage', $enId)
-        ->dispatch('eventImageUploadComponentSaved.pageComposer.mainPhoto', field: 'photo', imagePath: $state['page']['photo'])
-        ->set('page', $state['page'])
+        ->dispatch('eventImageUploadComponentSaved.pageComposer.mainPhoto', field: 'photo', imagePath: $state['pageData']['photo'])
+        ->set('pageData', $state['pageData'])
         ->set('pageCategory', ['id' => $this->category->id])
         ->set('pageTranslations', $state['pageTranslations'])
         ->set('rows', $state['rows'])
@@ -159,8 +159,8 @@ it('rolls back DB writes and shows a sanitized error when persist throws', funct
 
     $component = Livewire::test(PageComposer::class)
         ->call('addLanguage', $enId)
-        ->dispatch('eventImageUploadComponentSaved.pageComposer.mainPhoto', field: 'photo', imagePath: $state['page']['photo'])
-        ->set('page', $state['page'])
+        ->dispatch('eventImageUploadComponentSaved.pageComposer.mainPhoto', field: 'photo', imagePath: $state['pageData']['photo'])
+        ->set('pageData', $state['pageData'])
         ->set('pageCategory', ['id' => $this->category->id])
         ->set('pageTranslations', $state['pageTranslations'])
         ->set('rows', $rowsBefore)
@@ -198,7 +198,7 @@ it('routes the imageSaved listener through the field whitelist', function () {
 
     $component
         ->assertSet('photo', 'photos/hi.jpg')
-        ->assertSet('page.photo', 'photos/hi.jpg');
+        ->assertSet('pageData.photo', 'photos/hi.jpg');
 });
 
 it('ignores imageSaved events for fields outside the whitelist', function () {

--- a/tests/Feature/PageComposerComponentTest.php
+++ b/tests/Feature/PageComposerComponentTest.php
@@ -1,0 +1,212 @@
+<?php
+
+use Flobbos\PageComposer\Livewire\PageComposer;
+use Flobbos\PageComposer\Models\Category;
+use Flobbos\PageComposer\Models\ColumnItem;
+use Flobbos\PageComposer\Models\Element;
+use Flobbos\PageComposer\Models\Page;
+use Flobbos\PageComposer\Models\PageTranslation;
+use Flobbos\PageComposer\Models\Row;
+use Flobbos\PageComposer\Services\PageBuilder;
+use Flobbos\PageComposer\Services\PageBuilderResult;
+use Illuminate\Support\Collection;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->languages = seedLanguages(['en', 'de']);
+    $this->element = seedElement('Text', 'text');
+    $this->category = Category::create([]);
+});
+
+/**
+ * Build a minimal in-memory state tree that satisfies the validation rules
+ * declared in pagecomposer.rules.
+ */
+function pageState(int $categoryId, int $elementId): array
+{
+    return [
+        'page' => [
+            'name' => 'Hello',
+            'photo' => 'photos/hello.jpg',
+            'newsletter_image' => null,
+            'slider_image' => null,
+            'published_on' => null,
+            'category_id' => $categoryId,
+        ],
+        'pageTranslations' => [
+            'en' => [
+                'language_id' => 1,
+                'content' => ['title' => 'Hello'],
+            ],
+        ],
+        'rows' => [
+            'en' => [
+                'rows' => [
+                    [
+                        'uuid' => 'tmp-1',
+                        'sorting' => 1,
+                        'alignment' => 'center',
+                        'expanded' => false,
+                        'active' => true,
+                        'attributes' => [],
+                        'columns' => [
+                            [
+                                'sorting' => 1,
+                                'column_size' => 6,
+                                'active' => true,
+                                'attributes' => [],
+                                'column_items' => [
+                                    [
+                                        'element_id' => $elementId,
+                                        'name' => 'Text',
+                                        'component' => 'text',
+                                        'icon' => '<svg></svg>',
+                                        'sorting' => 1,
+                                        'active' => true,
+                                        'attributes' => [],
+                                        'content' => ['body' => 'Lorem'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+}
+
+it('mounts with a default page array when no id is provided', function () {
+    Livewire::test(PageComposer::class)
+        ->assertSet('pageId', null)
+        ->assertSet('page.name', null)
+        ->assertSet('page.photo', null);
+});
+
+it('hydrates from the DB when mounted with an existing page id', function () {
+    $page = new Page();
+    $page->name = 'Existing';
+    $page->photo = 'photos/existing.jpg';
+    $page->category_id = $this->category->id;
+    $page->save();
+    $page->translations()->create([
+        'language_id' => $this->languages->firstWhere('locale', 'en')->id,
+        'content' => ['title' => 'Existing'],
+        'slug' => 'existing',
+    ]);
+
+    Livewire::test(PageComposer::class, ['page' => $page->id])
+        ->assertSet('pageId', $page->id)
+        ->assertSet('page.name', 'Existing')
+        ->assertSet('page.photo', 'photos/existing.jpg')
+        ->assertSet('photo', 'photos/existing.jpg');
+});
+
+it('blocks saveContent when required fields are missing', function () {
+    Livewire::test(PageComposer::class)
+        ->call('saveContent', false)
+        ->assertHasErrors(['page.name', 'page.photo', 'page.category_id']);
+
+    expect(Page::count())->toBe(0);
+});
+
+it('persists through saveContent on the happy path', function () {
+    $state = pageState($this->category->id, $this->element->id);
+    $enId = $this->languages->firstWhere('locale', 'en')->id;
+
+    $component = Livewire::test(PageComposer::class)
+        ->call('addLanguage', $enId)
+        ->dispatch('eventImageUploadComponentSaved.pageComposer.mainPhoto', field: 'photo', imagePath: $state['page']['photo'])
+        ->set('page', $state['page'])
+        ->set('pageCategory', ['id' => $this->category->id])
+        ->set('pageTranslations', $state['pageTranslations'])
+        ->set('rows', $state['rows'])
+        ->call('saveContent', false)
+        ->assertHasNoErrors();
+
+    expect($component->get('exceptionMessage'))->toBeNull();
+    expect(Page::count())->toBe(1);
+    expect(PageTranslation::count())->toBe(1);
+    expect(Row::count())->toBe(1);
+    expect(ColumnItem::count())->toBe(1);
+});
+
+it('rolls back DB writes and shows a sanitized error when persist throws', function () {
+    // Swap PageBuilder for one that always blows up after the page row is
+    // created, simulating a mid-transaction failure. Returning rows that
+    // would otherwise be valid lets us assert the rollback by counting
+    // rows in the DB.
+    app()->bind(PageBuilder::class, function () {
+        return new class extends PageBuilder {
+            public function persist(?int $pageId, array $pageData, array $pageTranslations, array $pageTags, array $rows, Collection $languagesByLocale): PageBuilderResult
+            {
+                return \Illuminate\Support\Facades\DB::transaction(function () use ($pageData) {
+                    $page = new Page();
+                    $page->name = $pageData['name'] ?? null;
+                    $page->photo = $pageData['photo'] ?? null;
+                    $page->category_id = $pageData['category_id'] ?? null;
+                    $page->save();
+
+                    throw new \RuntimeException('simulated failure with /etc/passwd path');
+                });
+            }
+        };
+    });
+
+    $state = pageState($this->category->id, $this->element->id);
+    $rowsBefore = $state['rows'];
+    $enId = $this->languages->firstWhere('locale', 'en')->id;
+
+    $component = Livewire::test(PageComposer::class)
+        ->call('addLanguage', $enId)
+        ->dispatch('eventImageUploadComponentSaved.pageComposer.mainPhoto', field: 'photo', imagePath: $state['page']['photo'])
+        ->set('page', $state['page'])
+        ->set('pageCategory', ['id' => $this->category->id])
+        ->set('pageTranslations', $state['pageTranslations'])
+        ->set('rows', $rowsBefore)
+        ->call('saveContent', false);
+
+    // Transaction rolled back: no Page row survived.
+    expect(Page::count())->toBe(0);
+
+    // In-memory rows still match what we sent in (no IDs leaked from a
+    // partial commit, no mutations from the fake builder).
+    $component->assertSet('rows', $rowsBefore);
+    $component->assertSet('pageId', null);
+
+    // User-facing message is the sanitized constant; the raw exception
+    // message (with the path) is not surfaced.
+    $component->assertSet('showErrorMessage', true);
+    $component->assertSet('exceptionMessage', 'We could not save this page. Please try again.');
+});
+
+it('removes a row from state when the deleteRow listener fires', function () {
+    $state = pageState($this->category->id, $this->element->id);
+    $enId = $this->languages->firstWhere('locale', 'en')->id;
+
+    $component = Livewire::test(PageComposer::class)
+        ->call('addLanguage', $enId)
+        ->set('rows', $state['rows'])
+        ->dispatch('deleteRow', '0');
+
+    expect($component->get('rows.en.rows'))->toHaveCount(0);
+});
+
+it('routes the imageSaved listener through the field whitelist', function () {
+    $component = Livewire::test(PageComposer::class)
+        ->dispatch('eventImageUploadComponentSaved.pageComposer.mainPhoto', field: 'photo', imagePath: 'photos/hi.jpg');
+
+    $component
+        ->assertSet('photo', 'photos/hi.jpg')
+        ->assertSet('page.photo', 'photos/hi.jpg');
+});
+
+it('ignores imageSaved events for fields outside the whitelist', function () {
+    $component = Livewire::test(PageComposer::class)
+        ->dispatch('eventImageUploadComponentSaved.pageComposer.mainPhoto', field: 'arbitrary_property', imagePath: '/etc/passwd');
+
+    // The component should not now have an arbitrary_property attribute set.
+    expect($component->get('photo'))->toBeNull();
+    expect($component->get('newsletter_image'))->toBeNull();
+    expect($component->get('slider_image'))->toBeNull();
+});

--- a/tests/Fixtures/StubElement.php
+++ b/tests/Fixtures/StubElement.php
@@ -11,10 +11,10 @@ use Livewire\Component;
  */
 class StubElement extends Component
 {
-    public $data;
+    public $data = [];
     public $itemKey;
     public $sorting;
-    public $previewMode;
+    public $previewMode = false;
     public $target;
 
     public function render()

--- a/tests/Fixtures/StubElement.php
+++ b/tests/Fixtures/StubElement.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Flobbos\PageComposer\Tests\Fixtures;
+
+use Livewire\Component;
+
+/**
+ * Stand-in for the user-published page-composer-elements.* Livewire
+ * components. Registered under each element name we use in tests so the
+ * orchestrator's Blade view can render rows that contain column items.
+ */
+class StubElement extends Component
+{
+    public $data;
+    public $itemKey;
+    public $sorting;
+    public $previewMode;
+    public $target;
+
+    public function render()
+    {
+        return '<div data-stub-element></div>';
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,9 +3,11 @@
 namespace Flobbos\PageComposer\Tests;
 
 use Flobbos\PageComposer\PageComposerServiceProvider;
+use Flobbos\PageComposer\Tests\Fixtures\StubElement;
 use Flobbos\PageComposer\Tests\Fixtures\User;
 use Flobbos\TranslatableDB\TranslatableDBServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 use BladeUI\Heroicons\BladeHeroiconsServiceProvider;
@@ -18,6 +20,14 @@ abstract class TestCase extends Orchestra
     protected function setUp(): void
     {
         parent::setUp();
+
+        // The page-composer-elements.* Livewire components are published
+        // into the host app on install. In tests we register a single
+        // stub under each element name we use so the orchestrator's view
+        // can render rows that contain column items.
+        foreach (['text', 'photo', 'youtube'] as $component) {
+            Livewire::component('page-composer-elements.' . $component, StubElement::class);
+        }
     }
 
     protected function getPackageProviders($app): array
@@ -33,6 +43,8 @@ abstract class TestCase extends Orchestra
 
     protected function defineEnvironment($app): void
     {
+        $app['config']->set('app.key', 'base64:' . base64_encode(random_bytes(32)));
+
         $app['config']->set('database.default', 'testing');
         $app['config']->set('database.connections.testing', [
             'driver' => 'sqlite',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,16 +17,30 @@ abstract class TestCase extends Orchestra
 {
     use RefreshDatabase;
 
+    /**
+     * Element `component` names registered against StubElement. The package's
+     * real element classes are only available after publishing to the host
+     * app, so any Livewire element name the tests emit must be added here.
+     */
+    protected array $elementStubs = [
+        'text',
+        'photo',
+        'headline-text',
+        'hero-banner',
+        'grid-cards',
+        'bullet-list-features',
+        'testimonials-trust-badges',
+        'accordion-faq',
+        'call-to-action-section',
+        'you-tube',
+    ];
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        // The page-composer-elements.* Livewire components are published
-        // into the host app on install. In tests we register a single
-        // stub under each element name we use so the orchestrator's view
-        // can render rows that contain column items.
-        foreach (['text', 'photo', 'youtube'] as $component) {
-            Livewire::component('page-composer-elements.' . $component, StubElement::class);
+        foreach ($this->elementStubs as $name) {
+            Livewire::component('page-composer-elements.' . $name, StubElement::class);
         }
     }
 

--- a/tests/Unit/SortServiceTest.php
+++ b/tests/Unit/SortServiceTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use Flobbos\PageComposer\Services\SortService;
+
+uses()->group('unit');
+
+beforeEach(function () {
+    $this->service = new SortService();
+});
+
+it('returns the input untouched when no items are provided', function () {
+    $result = $this->service->reorder([], fn() => '', 0, 0);
+
+    expect($result)->toBe([]);
+});
+
+it('returns the input untouched when the source key cannot be resolved', function () {
+    $items = [
+        ['id' => 'a', 'sorting' => 1],
+        ['id' => 'b', 'sorting' => 2],
+    ];
+
+    $result = $this->service->reorder(
+        $items,
+        fn(array $item) => $item['id'],
+        'missing',
+        1,
+    );
+
+    expect($result)->toBe($items);
+});
+
+it('moves the source item to the requested zero-based position', function () {
+    $items = [
+        ['id' => 'a', 'sorting' => 1],
+        ['id' => 'b', 'sorting' => 2],
+        ['id' => 'c', 'sorting' => 3],
+    ];
+
+    $result = $this->service->reorder(
+        $items,
+        fn(array $item) => $item['id'],
+        'a',
+        2,
+    );
+
+    expect(collect($result)->sortBy('sorting')->pluck('id')->all())
+        ->toBe(['b', 'c', 'a']);
+});
+
+it('rewrites sortings to a 1-based contiguous sequence', function () {
+    $items = [
+        ['id' => 'a', 'sorting' => 10],
+        ['id' => 'b', 'sorting' => 20],
+        ['id' => 'c', 'sorting' => 30],
+    ];
+
+    $result = $this->service->reorder(
+        $items,
+        fn(array $item) => $item['id'],
+        'c',
+        0,
+    );
+
+    expect(collect($result)->pluck('sorting')->sort()->values()->all())
+        ->toBe([1, 2, 3]);
+});
+
+it('preserves original array keys', function () {
+    $items = [
+        7 => ['id' => 'a', 'sorting' => 1],
+        9 => ['id' => 'b', 'sorting' => 2],
+        4 => ['id' => 'c', 'sorting' => 3],
+    ];
+
+    $result = $this->service->reorder(
+        $items,
+        fn(array $item) => $item['id'],
+        'b',
+        0,
+    );
+
+    expect(array_keys($result))->toBe([7, 9, 4]);
+});
+
+it('clamps a negative position to zero', function () {
+    $items = [
+        ['id' => 'a', 'sorting' => 1],
+        ['id' => 'b', 'sorting' => 2],
+        ['id' => 'c', 'sorting' => 3],
+    ];
+
+    $result = $this->service->reorder(
+        $items,
+        fn(array $item) => $item['id'],
+        'c',
+        -10,
+    );
+
+    expect(collect($result)->sortBy('sorting')->pluck('id')->first())->toBe('c');
+});
+
+it('places the source at the end when the position exceeds the count', function () {
+    $items = [
+        ['id' => 'a', 'sorting' => 1],
+        ['id' => 'b', 'sorting' => 2],
+        ['id' => 'c', 'sorting' => 3],
+    ];
+
+    $result = $this->service->reorder(
+        $items,
+        fn(array $item) => $item['id'],
+        'a',
+        99,
+    );
+
+    expect(collect($result)->sortBy('sorting')->pluck('id')->last())->toBe('a');
+});
+
+it('uses the array key when the resolver returns it', function () {
+    $items = [
+        ['id' => 'a', 'sorting' => 1],
+        ['id' => 'b', 'sorting' => 2],
+        ['id' => 'c', 'sorting' => 3],
+    ];
+
+    $result = $this->service->reorder(
+        $items,
+        fn(array $item, $key) => (string) $key,
+        '2',
+        0,
+    );
+
+    expect(collect($result)->sortBy('sorting')->pluck('id')->first())->toBe('c');
+});


### PR DESCRIPTION
## Summary

Structural rewrite of the `PageComposer` Livewire component for the 2.0.0 line. Same Laravel 13 / Livewire 4 / PHP 8.3 baseline as 1.x, no schema changes. 15 commits, each individually reviewable.

- `Livewire/PageComposer.php`: **902 → 333 lines** (orchestration only)
- New `Services/` namespace: `PageBuilder`, `PageBuilderResult`, `PageComposerCache`, `SortService`
- New `Livewire/Concerns/` namespace: `HandlesImageUploads`, `HandlesTemplates`, `InteractsWithLanguages`, `ManagesRows`
- **Pest 4 test suite: 49 tests, 130 assertions, all green** (in-memory sqlite via Orchestra Testbench)

Integrates both `release-2.0` commits that landed after this branch diverged (`164d538`, `83bbd54`) — a clean fast-forward isn't possible (different histories), but the result is strictly ahead.

## What changed

### Correctness & safety (P0)
- Save / update wrapped in `DB::transaction` — no more orphan rows on partial failure
- Sanitized error messages — `report($ex)` to your error reporter, generic message to the user (previously leaked `$ex->getMessage() . line . file` into a session flash)
- Languages pre-loaded once per save instead of `Language::where('locale', $key)->first()` per translation and per row

### Architecture (P1)
- `saveContent` + `updateContent` merged into one upsert path via `PageBuilder::persist` (was ~100 lines of duplicated triple-nested foreach)
- Four cache methods (elements, languages, categories, tags) collapsed into `PageComposerCache`
- Six copy-paste image-upload listeners collapsed to two stacked-attribute methods with a field whitelist; routed through a new `field` payload from `ImageUploadComponent`
- Row + column reorder algorithm extracted to `SortService::reorder`
- Component split into four concern traits

### Deferred structural deletes (ported from `release-2.0` `83bbd54`)
- Row / column / element removal now staged in editor state, applied to DB only on save
- `PageBuilder::persist` runs `purgeOrphans()` inside the transaction — compares kept ids against `WHERE page_id = ?` rows and `whereNotIn` deletes the rest
- Refresh before save restores the removed content
- Confirm dialog copy: "Applied when you save the page."

### Modern Livewire 4 surface (P2)
- `$page` → typed `?array $pageData = null` (decoupled from mount's `$page` route param)
- `#[Locked]` on every server-controlled property (elements, pageId, languages, photo, etc.) — blocks frontend payload tampering
- `RowComponent::$row` and `ColumnComponent::$column` now `#[Modelable]`; bound via `wire:model="rows.{locale}.rows.{rowKey}"` and `wire:model="row.columns.{columnKey}"`. Three-hop dispatch chain (`itemsUpdated.{target}` → `columnUpdated` → `rowUpdated`) deleted.
- `pagecomposer.date_format` config key (default `'m-d-Y'` for parity; recommended `'Y-m-d'`)
- ServiceProvider Livewire registration driven by a class-list constant + `Str::kebab(class_basename(...))` loop (was 17 individual `Livewire::component(...)` lines)
- `ElementComponent::render()` reads from `PageComposerCache` instead of `Element::all()` on every render

### Test suite
- `tests/Unit/SortServiceTest.php` — 8 tests, pure-function reorder coverage
- `tests/Feature/PageComposerCacheTest.php` — 7 tests, cache hit/refresh/forget
- `tests/Feature/PageBuilderTest.php` — 12 tests, persistence + rollback
- `tests/Feature/PageComposerComponentTest.php` — 8 tests, Livewire orchestrator (mount, validation, happy-path save, rollback safety with sanitized error, listeners)
- `tests/Feature/ColumnComponentTest.php` — 5 tests, sort/delete/position (from `release-2.0` `164d538`)
- `tests/Feature/HarnessTest.php` — 3 tests, provider boot + migrations (from `release-2.0` `164d538`)
- `tests/Feature/DeferredDeleteTest.php` — 6 tests, the staged-delete behaviour (from `release-2.0` `83bbd54`)
- `tests/Fixtures/StubElement.php` registered under `page-composer-elements.{10 names}` so the orchestrator's view renders without published host-app element classes

## Breaking changes

Documented in `changelog.md` and a new "Upgrading from 1.x to 2.x" section in the README. Highlights:

1. Validation rule keys: `page.*` → `pageData.*` (config-level rename)
2. Row / column children bind via `wire:model`, not `:row=` / `:column=`
3. `ImageUploadComponent` views must pass `fieldName="..."` to route to a PageComposer photo field
4. `#[Locked]` properties throw on frontend writes — switch to the corresponding event
5. Sanitized error messages — wire up `report()` if you want detail
6. Pest plugin dependencies bumped to `^4.0`

## Test plan

- [ ] `composer update && vendor/bin/pest` — should report 49 tests / 130 assertions green
- [ ] In a browser against a real LV13 / LW4 host app: edit an existing page, drag a column, add a row, add an element, save → confirm state survives the round trip
- [ ] Refresh before save → confirm a removed row/column/element is restored (deferred-delete feature)
- [ ] Image upload flow for all three fields (main photo, slider image, newsletter image)
- [ ] Date picker against your locale (default is still `m-d-Y` for back-compat; flip to `'Y-m-d'` in config if you want)
- [ ] If you have custom validation rules in a published `pagecomposer.php`, rename `page.*` to `pageData.*` before testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cRFEXzTc1oWHvMmiwHEWa

---
_Generated by [Claude Code](https://claude.ai/code/session_019cRFEXzTc1oWHvMmiwHEWa)_